### PR TITLE
#19 jaxb dependency for coveralls plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,13 @@
                         <configuration>
                             <failOnServiceError>false</failOnServiceError>
                         </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>javax.xml.bind</groupId>
+                                <artifactId>jaxb-api</artifactId>
+                                <version>2.2.3</version>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
#19 
added required dependency for coveralls plugin. JDK 11 kicked out the jaxb api.