### PR TITLE
#20 Repos replaced with Provider

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Provider.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Provider.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2020, Self XDSD Contributors
  * All rights reserved.
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"),
  * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
  * modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software.
- *
+ * <p>
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -23,10 +23,25 @@
 package com.selfxdsd.api;
 
 /**
- * A com.selfxdsd.api.User's repositories on Github, Bitbucket, Gitlab etc.
+ * A Provider is a platform against which the User is authenticated and
+ * which holds the User's repos (Github, Gitlab, Bitbucket etc).
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
  */
-public interface Repos extends Iterable<Repo> {
+public interface Provider {
+
+    /**
+     * Name of this provider.
+     * @return String.
+     */
+    String name();
+
+    /**
+     * Get a Repo by its simple name. E.g. "testrepo" is the simple name
+     * of repo "amihaiemil/testrepo".
+     * @param name Simple name of the repo.
+     * @return Repo.
+     */
+    Repo repo(final String name);
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/Github.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/Github.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2020, Self XDSD Contributors
  * All rights reserved.
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"),
  * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
  * modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software.
- *
+ * <p>
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -20,45 +20,59 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.selfxdsd.api;
-import java.net.URL;
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Provider;
+import com.selfxdsd.api.Repo;
+import com.selfxdsd.api.User;
+import java.net.URI;
 
 /**
- * User.
+ * Github as a Provider.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
+ * @todo #20:30min Implemented method repo(). Write unit tests,
+ *  as well as integration tests for it. This method assumes that
+ *  the repo in question is a user-owned and public.
  */
-public interface User {
+final class Github implements Provider {
 
     /**
-     * User's name.
-     * @return String.
+     * User.
      */
-    String username();
+    private final User user;
 
     /**
-     * User's email address.
-     * @return String.
+     * Github's URI.
      */
-    String email();
+    private final URI uri;
 
     /**
-     * User's avatar URL.
-     * @return URL.
+     * Constructor.
+     * @param user Authenticated user.
      */
-    URL avatar();
+    Github(final User user) {
+        this(user, URI.create("https://api.github.com"));
+    }
 
     /**
-     * Provider. Github, Bitbucket, Gitlab etc.
-     * @return String.
+     * Constructor.
+     * @param user Authenticated user.
+     * @param uri Base URI of Github's API.
      */
-    Provider provider();
+    Github(final User user, final URI uri) {
+        this.user = user;
+        this.uri = uri;
+    }
 
-    /**
-     * A User's projects (activated repositories), managed
-     * by the platform.
-     * @return Projects.
-     */
-    Projects projects();
+    @Override
+    public String name() {
+        return "github";
+    }
+
+    @Override
+    public Repo repo(final String name) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubSelf.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubSelf.java
@@ -22,9 +22,9 @@
  */
 package com.selfxdsd.core;
 
+import com.selfxdsd.api.Provider;
 import com.selfxdsd.api.User;
 import com.selfxdsd.api.Storage;
-import com.selfxdsd.api.Repos;
 import com.selfxdsd.api.Projects;
 
 import java.net.URL;
@@ -34,10 +34,6 @@ import java.net.URL;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
- * @todo #15:30min Implement User.repos(). It should return a
- *  Repos instance which should represent the user's repository
- *  from the provider's platform (Github, Bitbucket etc). GithubRepo
- *  is already implemented, we can start with Github Repos.
  */
 public final class GithubSelf extends BaseSelf {
 
@@ -82,13 +78,8 @@ public final class GithubSelf extends BaseSelf {
             }
 
             @Override
-            public String provider() {
-                return "github";
-            }
-
-            @Override
-            public Repos repos() {
-                return null;
+            public Provider provider() {
+                return new Github(this);
             }
 
             @Override
@@ -102,7 +93,7 @@ public final class GithubSelf extends BaseSelf {
     public User authenticated() {
         final Storage storage = this.storage();
         User authenticated = storage.users().user(
-            this.user.username(), this.user.provider()
+            this.user.username(), this.user.provider().name()
         );
         if(authenticated == null) {
             authenticated = storage.users().signUp(this.user);

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubSelfTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubSelfTestCase.java
@@ -58,6 +58,10 @@ public final class GithubSelfTestCase {
             Matchers.equalTo("amihaiemil")
         );
         MatcherAssert.assertThat(
+            amihaiemil.provider(),
+            Matchers.instanceOf(Github.class)
+        );
+        MatcherAssert.assertThat(
             storage.users(), Matchers.iterableWithSize(1)
         );
         MatcherAssert.assertThat(

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryUsers.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryUsers.java
@@ -45,7 +45,9 @@ public final class InMemoryUsers implements Users {
 
     @Override
     public User signUp(final User user) {
-        final UserKey key = new UserKey(user.username(), user.provider());
+        final UserKey key = new UserKey(
+            user.username(), user.provider().name()
+        );
         final User signedUp = this.users.get(key);
         if(signedUp == null) {
             this.users.put(key, user);


### PR DESCRIPTION
PR for #20 

* Interface ``Repos`` replaced with ``Provider``. At the moment we are interested only in the public repositories which can be fetched and displayed on the front-end, while the backend expects only the repo's name to fetch it from the provider;

* ``Github`` is the first Provider we have;
* Left puzzle for continuing with method ``Github.repo()``;