### PR TITLE
#79 InMemoryContributors.getById + register

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Contract.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Contract.java
@@ -29,6 +29,9 @@ import java.math.BigDecimal;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
+ * @todo #79:30min Implement and test StoredContract, following the
+ *  pattern of StoredContributor and others. This is a good ticket
+ *  for first-time contributors.
  */
 public interface Contract {
 

--- a/self-api/src/main/java/com/selfxdsd/api/Contributors.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Contributors.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2020, Self XDSD Contributors
  * All rights reserved.
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"),
  * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
  * modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software.
- *
+ * <p>
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -20,66 +20,30 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.selfxdsd.core.mock;
-
-import com.selfxdsd.api.*;
-import com.selfxdsd.api.storage.Storage;
+package com.selfxdsd.api;
 
 /**
- * In Memory storage used for testing.
+ * Contributors in Self.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
  */
-public final class InMemory implements Storage {
+public interface Contributors extends Iterable<Contributor> {
 
     /**
-     * In-memory users.
+     * Register a new contributor in Self.
+     * @param username Username.
+     * @param provider Password.
+     * @return Contributor.
      */
-    private Users users = new InMemoryUsers();
-    /**
-     * In-memory project-managers.
-     */
-    private ProjectManagers projectManagers = new InMemoryProjectManagers(this);
-
-    /**
-     * In-memory projects.
-     */
-    private Projects projects = new InMemoryProjects(this);
+    Contributor register(final String username, final String provider);
 
     /**
-     * In-memory contracts.
+     * Get a Contributor by his id.
+     * @param username Username.
+     * @param provider Provider name.
+     * @return Contributor or null if not found.
      */
-    private Contracts contracts = new InMemoryContracts(this);
+    Contributor getById(final String username, final String provider);
 
-    /**
-     * In-memory contributors.
-     */
-    private Contributors contributors = new InMemoryContributors(this);
-
-
-    @Override
-    public Users users() {
-        return this.users;
-    }
-
-    @Override
-    public ProjectManagers projectManagers() {
-        return this.projectManagers;
-    }
-
-    @Override
-    public Projects projects() {
-        return this.projects;
-    }
-
-    @Override
-    public Contracts contracts() {
-        return this.contracts;
-    }
-
-    @Override
-    public Contributors contributors() {
-        return this.contributors;
-    }
 }

--- a/self-api/src/main/java/com/selfxdsd/api/storage/Storage.java
+++ b/self-api/src/main/java/com/selfxdsd/api/storage/Storage.java
@@ -22,10 +22,7 @@
  */
 package com.selfxdsd.api.storage;
 
-import com.selfxdsd.api.Contracts;
-import com.selfxdsd.api.ProjectManagers;
-import com.selfxdsd.api.Projects;
-import com.selfxdsd.api.Users;
+import com.selfxdsd.api.*;
 
 /**
  * Storage of Self.
@@ -58,4 +55,10 @@ public interface Storage {
      * @return Contracts.
      */
     Contracts contracts();
+
+    /**
+     * Get the contributors Storage API.
+     * @return Contributors.
+     */
+    Contributors contributors();
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryContributors.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryContributors.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core.mock;
+
+import com.selfxdsd.api.Contributor;
+import com.selfxdsd.api.Contributors;
+import com.selfxdsd.api.storage.Storage;
+import com.selfxdsd.core.contributors.StoredContributor;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * In-memory contributors for test purposes.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.1
+ * @todo #79:30min Write some unit tests for this class, make sure
+ *  it works fine. This is a good starting point if you want to start
+ *  contributing to self-core.
+ */
+public final class InMemoryContributors implements Contributors {
+
+    /**
+     * Parent storage.
+     */
+    private final Storage storage;
+
+    /**
+     * Contributors "table".
+     */
+    private final Map<ContributorKey, Contributor> table = new HashMap<>();
+
+    /**
+     * Ctor.
+     * @param storage Parent storage.
+     */
+    public InMemoryContributors(final Storage storage) {
+        this.storage = storage;
+    }
+
+    @Override
+    public Contributor register(final String username, final String provider) {
+        final ContributorKey key = new ContributorKey(username, provider);
+        final Contributor contributor = this.table.get(key);
+        if(contributor != null) {
+            throw new IllegalArgumentException("Contributor already exists.");
+        } else {
+            final Contributor newContributor = new StoredContributor(
+                username, provider, this.storage
+            );
+            this.table.put(key, newContributor);
+            return newContributor;
+        }
+    }
+
+    @Override
+    public Contributor getById(
+        final String username, final String provider
+    ) {
+        return this.table.get(new ContributorKey(username, provider));
+    }
+
+    @Override
+    public Iterator<Contributor> iterator() {
+        return this.table.values().iterator();
+    }
+
+    /**
+     * Contributor primary key.
+     *
+     * @checkstyle VisibilityModifier (50 lines)
+     */
+    private static class ContributorKey {
+
+        /**
+         * Contributor's username.
+         */
+        private final String contributorUsername;
+
+        /**
+         * Contributor's provider.
+         */
+        private final String contributorProvider;
+
+        /**
+         * Constructor.
+         *
+         * @param contributorUsername Contributor's username.
+         * @param contributorProvider Contributor's provider.
+         * */
+        ContributorKey(
+            final String contributorUsername,
+            final String contributorProvider
+        ) {
+            this.contributorUsername = contributorUsername;
+            this.contributorProvider = contributorProvider;
+        }
+
+        @Override
+        public boolean equals(final Object object) {
+            if (this == object) {
+                return true;
+            }
+            if (object == null || getClass() != object.getClass()) {
+                return false;
+            }
+            final InMemoryContributors.ContributorKey contractKey =
+                (InMemoryContributors.ContributorKey) object;
+            //@checkstyle LineLength (5 lines)
+            return this.contributorUsername.equals(contractKey.contributorUsername)
+                && this.contributorProvider.equals(contractKey.contributorProvider);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(
+                this.contributorUsername,
+                this.contributorProvider
+            );
+        }
+    }
+}


### PR DESCRIPTION
PR for #79 

* Implemented ``Contributors`` and ``InMemoryContributors`` with methods ``register`` and ``getById``
* Used them inside ``InMemoryContracts``
* Updated unit tests for ``InMemoryContracts``

* Left puzzle for unit testing ``InMemoryContracts``
* Left puzzle for implementing ``Project :: Projects.getById``
* Left puzzle for implementing ``StoredContract``.