### PR TITLE
#136 Implemented and unit tested Contributor.tasks()

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Contributor.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Contributor.java
@@ -48,4 +48,10 @@ public interface Contributor {
      */
     Contracts contracts();
 
+    /**
+     * This contributor's tasks.
+     * @return Tasks
+     */
+    Tasks tasks();
+
 }

--- a/self-api/src/main/java/com/selfxdsd/api/Tasks.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Tasks.java
@@ -27,8 +27,6 @@ package com.selfxdsd.api;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
- * @todo #133:30min Implement and unit test Contributor.tasks().
- *  It should return its own implementation of Tasks.
  */
 public interface Tasks extends Iterable<Task> {
 
@@ -63,5 +61,14 @@ public interface Tasks extends Iterable<Task> {
         final String repoFullName,
         final String repoProvider
     );
+
+    /**
+     * Get the tasks of a given Contributor.
+     * @param username Contributor's user name
+     * @param provider Contributor's Provider
+     * @return Tasks.
+     */
+    Tasks ofContributor(final String username,
+                        final String provider);
 
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contributors/StoredContributor.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contributors/StoredContributor.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core.contributors;
 
 import com.selfxdsd.api.Contracts;
 import com.selfxdsd.api.Contributor;
+import com.selfxdsd.api.Tasks;
 import com.selfxdsd.api.storage.Storage;
 
 /**
@@ -78,5 +79,10 @@ public final class StoredContributor implements Contributor {
     @Override
     public Contracts contracts() {
         return this.storage.contracts().ofContributor(this);
+    }
+
+    @Override
+    public Tasks tasks() {
+        return this.storage.tasks().ofContributor(this.username, this.provider);
     }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContributorTasks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContributorTasks.java
@@ -68,15 +68,7 @@ public final class ContributorTasks implements Tasks {
 
     @Override
     public Task register(final Issue issue) {
-        if (!this.provider.equals(issue.provider())) {
-            throw new IllegalArgumentException(
-                "The given Issue does not belong to the Provider "
-                    + this.provider + "."
-            );
-        }
-        Task task = this.storage.tasks().register(issue);
-        tasks.add(task);
-        return task;
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContributorTasks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContributorTasks.java
@@ -18,6 +18,10 @@ import java.util.stream.StreamSupport;
  * @author criske
  * @version $Id$
  * @since 0.0.1
+ * @todo #134:30min In `InMemoryTasks.java` Implement and unit test method
+ *  ofContributor(...) which should return the specified
+ *  Contributor tasks using class
+ *  {@link com.selfxdsd.core.tasks.ContributorTasks}.
  */
 public final class ContributorTasks implements Tasks {
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContributorTasks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContributorTasks.java
@@ -47,7 +47,7 @@ public final class ContributorTasks implements Tasks {
      * @param username Contributor's user name.
      * @param provider Contributor's provider.
      * @param tasks Contributor's tasks.
-     * @param storage Self's storage, to save new contracts.
+     * @param storage Self's storage, to save new tasks.
      */
     public ContributorTasks(final String username,
                             final String provider,

--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContributorTasks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContributorTasks.java
@@ -1,0 +1,111 @@
+package com.selfxdsd.core.tasks;
+
+import com.selfxdsd.api.Issue;
+import com.selfxdsd.api.Task;
+import com.selfxdsd.api.Tasks;
+import com.selfxdsd.api.storage.Storage;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Active tasks of a Contributor. This class <b>just represents</b>
+ * the tasks. The actual filtering has to be done in an upper layer.
+ *
+ * @author criske
+ * @version $Id$
+ * @since 0.0.1
+ */
+public final class ContributorTasks implements Tasks {
+
+    /**
+     * Contributor's user name.
+     */
+    private final String username;
+
+    /**
+     * Contributor's provider.
+     */
+    private final String provider;
+
+    /**
+     * The contributor's tasks.
+     */
+    private final List<Task> tasks;
+
+    /**
+     * Self storage, to save new contracts.
+     */
+    private final Storage storage;
+
+    /**
+     * Constructor.
+     *
+     * @param username Contributor's user name.
+     * @param provider Contributor's provider.
+     * @param tasks Contributor's tasks.
+     * @param storage Self's storage, to save new contracts.
+     */
+    public ContributorTasks(final String username,
+                            final String provider,
+                            final List<Task> tasks,
+                            final Storage storage) {
+        this.username = username;
+        this.provider = provider;
+        this.tasks = new ArrayList<>(tasks);
+        this.storage = storage;
+    }
+
+    @Override
+    public Task getById(final String issueId,
+                        final String repoFullName,
+                        final String provider) {
+        return this.storage.tasks().getById(issueId, repoFullName, provider);
+    }
+
+    @Override
+    public Task register(final Issue issue) {
+        if (!this.provider.equals(issue.provider())) {
+            throw new IllegalArgumentException(
+                "The given Issue does not belong to the Provider "
+                    + this.provider + "."
+            );
+        }
+        Task task = this.storage.tasks().register(issue);
+        tasks.add(task);
+        return task;
+    }
+
+    @Override
+    public Tasks ofProject(final String repoFullName,
+                           final String repoProvider) {
+        return this.storage.tasks().ofProject(repoFullName, repoProvider);
+    }
+
+    @Override
+    public Tasks ofContributor(final String username,
+                               final String provider) {
+        ContributorTasks tasks;
+        if (this.username.equals(username)
+            && this.provider.equals(provider)) {
+            tasks = this;
+        } else {
+            List<Task> ofContributor = StreamSupport
+                .stream(storage.tasks().spliterator(), false)
+                .filter(t -> t.assignee().username().equals(username)
+                    && t.assignee().provider().equals(provider))
+                .collect(Collectors.toList());
+            tasks = new ContributorTasks(username, provider, ofContributor,
+                storage);
+        }
+        return tasks;
+    }
+
+    @Override
+    public Iterator<Task> iterator() {
+        return this.tasks.iterator();
+    }
+}

--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ProjectTasks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ProjectTasks.java
@@ -128,6 +128,11 @@ public final class ProjectTasks implements Tasks {
     }
 
     @Override
+    public Tasks ofContributor(final String username, final String provider) {
+        return storage.tasks().ofContributor(username, provider);
+    }
+
+    @Override
     public Iterator<Task> iterator() {
         return this.tasks.iterator();
     }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contributors/StoredContributorTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contributors/StoredContributorTestCase.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core.contributors;
 
 import com.selfxdsd.api.Contracts;
 import com.selfxdsd.api.Contributor;
+import com.selfxdsd.api.Tasks;
 import com.selfxdsd.api.storage.Storage;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -79,6 +80,29 @@ public final class StoredContributorTestCase {
         MatcherAssert.assertThat(
             mihai.contracts(),
             Matchers.is(contracts)
+        );
+    }
+
+    /**
+     * StoredContributor can return his tasks.
+     */
+    @Test
+    public void returnsTasks() {
+        final Storage storage = Mockito.mock(Storage.class);
+        final Contributor mihai = new StoredContributor(
+            "mihai", "github", storage
+        );
+
+        final Tasks all = Mockito.mock(Tasks.class);
+        final Tasks tasks = Mockito.mock(Tasks.class);
+        Mockito.when(all.ofContributor(mihai.username(), mihai.provider()))
+            .thenReturn(tasks);
+
+        Mockito.when(storage.tasks()).thenReturn(all);
+
+        MatcherAssert.assertThat(
+            mihai.tasks(),
+            Matchers.is(tasks)
         );
     }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasks.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasks.java
@@ -36,9 +36,10 @@ import java.util.Objects;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
- * @todo #133:30min Implement and unit test method
- *  ofProject(...) which should return the specified
- *  Project tasks using class {@link com.selfxdsd.core.tasks.ProjectTasks}.
+ * @todo #134:30min Implement and unit test method
+ *  ofContributor(...) which should return the specified
+ *  Contributor tasks using class
+ *  {@link com.selfxdsd.core.tasks.ContributorTasks}.
  */
 public final class InMemoryTasks implements Tasks {
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasks.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasks.java
@@ -36,10 +36,6 @@ import java.util.Objects;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
- * @todo #134:30min Implement and unit test method
- *  ofContributor(...) which should return the specified
- *  Contributor tasks using class
- *  {@link com.selfxdsd.core.tasks.ContributorTasks}.
  */
 public final class InMemoryTasks implements Tasks {
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasks.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasks.java
@@ -22,10 +22,7 @@
  */
 package com.selfxdsd.core.mock;
 
-import com.selfxdsd.api.Issue;
-import com.selfxdsd.api.Project;
-import com.selfxdsd.api.Task;
-import com.selfxdsd.api.Tasks;
+import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
 import com.selfxdsd.core.tasks.StoredTask;
 
@@ -108,6 +105,11 @@ public final class InMemoryTasks implements Tasks {
         final String repoProvider
     ) {
         return null;
+    }
+
+    @Override
+    public Tasks ofContributor(final String username, final String provider) {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     /**

--- a/self-core-impl/src/test/java/com/selfxdsd/core/tasks/ContributorTasksTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/tasks/ContributorTasksTestCase.java
@@ -63,7 +63,8 @@ public final class ContributorTasksTestCase {
     }
 
     /**
-     * Should throw when register a new task associated with an issue.
+     * Should throw when register a new task associated with an issue
+     * with different provider.
      */
     @Test(expected = IllegalArgumentException.class)
     public void throwWhenIssueWithDifferentProvider() {
@@ -81,7 +82,7 @@ public final class ContributorTasksTestCase {
     }
 
     /**
-     * Should return new ContributorTask when searching for different
+     * Should return new ContributorTask when searching for same
      * contributor + provider key.
      */
     @Test
@@ -126,6 +127,32 @@ public final class ContributorTasksTestCase {
         MatcherAssert.assertThat(
             tasksOfMihai,
             Matchers.iterableWithSize(1)
+        );
+    }
+
+
+    /**
+     * Should return tasks of a project.
+     */
+    @Test
+    public void tasksOfProject(){
+        final Storage storage = Mockito.mock(Storage.class);
+        final Tasks tasks = new ContributorTasks(
+            "mihai", "github",
+            List.of(),
+            storage
+        );
+        final Tasks all = Mockito.mock(Tasks.class);
+        final Tasks ofProject = Mockito.mock(Tasks.class);
+        Mockito.when(all.ofProject(
+            Mockito.anyString(),
+            Mockito.anyString()
+        )).thenReturn(ofProject);
+        Mockito.when(storage.tasks()).thenReturn(all);
+
+        MatcherAssert.assertThat(
+            tasks.ofProject("mihai", "github"),
+            Matchers.equalTo(ofProject)
         );
     }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/tasks/ContributorTasksTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/tasks/ContributorTasksTestCase.java
@@ -1,0 +1,154 @@
+package com.selfxdsd.core.tasks;
+
+import com.selfxdsd.api.*;
+import com.selfxdsd.api.storage.Storage;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link ContributorTasks}.
+ *
+ * @author criske
+ * @version $Id$
+ * @since 0.0.1
+ */
+public final class ContributorTasksTestCase {
+
+    /**
+     * ContributorTasks should be iterable.
+     */
+    @Test
+    public void canBeIterated() {
+        final Tasks tasks = new ContributorTasks(
+            "foo",
+            "github", List.of(
+            Mockito.mock(Task.class),
+            Mockito.mock(Task.class),
+            Mockito.mock(Task.class)
+        ),
+            Mockito.mock(Storage.class)
+        );
+        MatcherAssert.assertThat(tasks, Matchers.iterableWithSize(3));
+    }
+
+    /**
+     * Should register a new task associated with an issue.
+     */
+    @Test
+    public void registerTask() {
+        final Task registered = Mockito.mock(Task.class);
+        final Issue issue = this.mockIssue(
+            "123",
+            "john/other",
+            "github",
+            Contract.Roles.DEV
+        );
+        Mockito.when(registered.issue()).thenReturn(issue);
+        final Tasks all = Mockito.mock(Tasks.class);
+        Mockito.when(all.register(issue)).thenReturn(registered);
+        final Storage storage = Mockito.mock(Storage.class);
+        Mockito.when(storage.tasks()).thenReturn(all);
+
+        final Tasks tasks = new ContributorTasks(
+            "foo", "github", List.of(),
+            storage
+        );
+        MatcherAssert.assertThat(tasks, Matchers.emptyIterable());
+        tasks.register(issue);
+        MatcherAssert.assertThat(tasks, Matchers.iterableWithSize(1));
+    }
+
+    /**
+     * Should throw when register a new task associated with an issue.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void throwWhenIssueWithDifferentProvider() {
+        final Issue issue = this.mockIssue(
+            "123",
+            "john/other",
+            "github",
+            Contract.Roles.DEV
+        );
+        final Tasks tasks = new ContributorTasks(
+            "foo", "gitlab", List.of(),
+            Mockito.mock(Storage.class)
+        );
+        tasks.register(issue);
+    }
+
+    /**
+     * Should return new ContributorTask when searching for different
+     * contributor + provider key.
+     */
+    @Test
+    public void returnSameTasksForSameUserNameProvider(){
+        final Tasks tasks = new ContributorTasks(
+            "foo", "gitlab", List.of(),
+            Mockito.mock(Storage.class)
+        );
+        MatcherAssert.assertThat(
+            tasks.ofContributor("foo", "gitlab"),
+            Matchers.equalTo(tasks)
+        );
+    }
+
+    /**
+     * Should return new ContributorTasks when searching for different
+     * contributor + provider key.
+     */
+    @Test
+    public void returnNewTasksForDiffUserNameProvider(){
+        final Storage storage = Mockito.mock(Storage.class);
+        final Task registered = Mockito.mock(Task.class);
+        final Contributor contributor = Mockito.mock(Contributor.class);
+        Mockito.when(contributor.username()).thenReturn("mihai");
+        Mockito.when(contributor.provider()).thenReturn("github");
+        Mockito.when(registered.assignee()).thenReturn(contributor);
+        final Tasks all = Mockito.mock(Tasks.class);
+        Mockito.when(all.spliterator())
+            .thenReturn(List.of(registered).spliterator());
+        Mockito.when(storage.tasks()).thenReturn(all);
+
+        final Tasks tasks = new ContributorTasks(
+            "foo", "gitlab", List.of(),
+            storage
+        );
+
+        Tasks tasksOfMihai = tasks.ofContributor("mihai", "github");
+        MatcherAssert.assertThat(
+            tasksOfMihai,
+            Matchers.not(Matchers.equalTo(tasks))
+        );
+        MatcherAssert.assertThat(
+            tasksOfMihai,
+            Matchers.iterableWithSize(1)
+        );
+    }
+
+
+
+
+    /**
+     * Mock an Issue for test.
+     *
+     * @param issueId ID.
+     * @param repoFullName Repo fullname.
+     * @param provider Provider.
+     * @param role Role.
+     * @return Issue.
+     */
+    private Issue mockIssue(
+        final String issueId, final String repoFullName,
+        final String provider, final String role) {
+        Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.issueId()).thenReturn(issueId);
+        Mockito.when(issue.repoFullName()).thenReturn(repoFullName);
+        Mockito.when(issue.provider()).thenReturn(provider);
+        Mockito.when(issue.role()).thenReturn(role);
+        return issue;
+    }
+}

--- a/self-core-impl/src/test/java/com/selfxdsd/core/tasks/ContributorTasksTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/tasks/ContributorTasksTestCase.java
@@ -37,49 +37,23 @@ public final class ContributorTasksTestCase {
 
     /**
      * Should register a new task associated with an issue.
+     * Right now is throwing UOE.
      */
-    @Test
+    @Test(expected = UnsupportedOperationException.class)
     public void registerTask() {
-        final Task registered = Mockito.mock(Task.class);
         final Issue issue = this.mockIssue(
             "123",
             "john/other",
             "github",
             Contract.Roles.DEV
         );
-        Mockito.when(registered.issue()).thenReturn(issue);
-        final Tasks all = Mockito.mock(Tasks.class);
-        Mockito.when(all.register(issue)).thenReturn(registered);
-        final Storage storage = Mockito.mock(Storage.class);
-        Mockito.when(storage.tasks()).thenReturn(all);
-
         final Tasks tasks = new ContributorTasks(
             "foo", "github", List.of(),
-            storage
-        );
-        MatcherAssert.assertThat(tasks, Matchers.emptyIterable());
-        tasks.register(issue);
-        MatcherAssert.assertThat(tasks, Matchers.iterableWithSize(1));
-    }
-
-    /**
-     * Should throw when register a new task associated with an issue
-     * with different provider.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void throwWhenIssueWithDifferentProvider() {
-        final Issue issue = this.mockIssue(
-            "123",
-            "john/other",
-            "github",
-            Contract.Roles.DEV
-        );
-        final Tasks tasks = new ContributorTasks(
-            "foo", "gitlab", List.of(),
             Mockito.mock(Storage.class)
         );
         tasks.register(issue);
     }
+
 
     /**
      * Should return new ContributorTask when searching for same

--- a/self-core-impl/src/test/java/com/selfxdsd/core/tasks/ProjectTasksTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/tasks/ProjectTasksTestCase.java
@@ -201,6 +201,31 @@ public final class ProjectTasksTestCase {
     }
 
     /**
+     * Should return tasks for contributor (name and provider).
+     */
+    @Test
+    public void returnTasksForContributor(){
+        final Storage storage = Mockito.mock(Storage.class);
+        final Tasks tasks = new ProjectTasks(
+            "john/test", "github",
+            List.of(),
+            storage
+        );
+        final Tasks all = Mockito.mock(Tasks.class);
+        final Tasks ofContributor = Mockito.mock(Tasks.class);
+        Mockito.when(all.ofContributor(
+            Mockito.anyString(),
+            Mockito.anyString()
+        )).thenReturn(ofContributor);
+        Mockito.when(storage.tasks()).thenReturn(all);
+
+        MatcherAssert.assertThat(
+            tasks.ofContributor("mihai", "github"),
+            Matchers.equalTo(ofContributor)
+        );
+    }
+
+    /**
      * Mock an Issue for test.
      * @param issueId ID.
      * @param repoFullName Repo fullname.


### PR DESCRIPTION
PR for #136 

Added `ofContributor(UserName,ProviderName)` in Tasks.
Stubbed `InMemoryTasks#ofContributor()`
Contributor#tasks() impl will return ContributorTasks via `storage.tasks.ofContributor`.
Implemented and tested `ContributorTasks`.
Implemented and tested `StoredContributor#tasks()`.

Removed puzzle.