### PR TITLE
#141 implemented InMemoryTasks#ofContributor.

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContributorTasks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContributorTasks.java
@@ -18,10 +18,6 @@ import java.util.stream.StreamSupport;
  * @author criske
  * @version $Id$
  * @since 0.0.1
- * @todo #134:30min In `InMemoryTasks.java` Implement and unit test method
- *  ofContributor(...) which should return the specified
- *  Contributor tasks using class
- *  {@link com.selfxdsd.core.tasks.ContributorTasks}.
  */
 public final class ContributorTasks implements Tasks {
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasks.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasks.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core.mock;
 
 import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
+import com.selfxdsd.core.tasks.ContributorTasks;
 import com.selfxdsd.core.tasks.ProjectTasks;
 import com.selfxdsd.core.tasks.StoredTask;
 
@@ -110,7 +111,12 @@ public final class InMemoryTasks implements Tasks {
 
     @Override
     public Tasks ofContributor(final String username, final String provider) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        final List<Task> tasksOf = tasks.values()
+            .stream()
+            .filter(t -> t.assignee().username().equals(username)
+                && t.assignee().provider().equals(provider))
+            .collect(Collectors.toList());
+        return new ContributorTasks(username, provider, tasksOf, storage);
     }
 
     /**

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasksTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasksTestCase.java
@@ -34,6 +34,9 @@ import org.mockito.Mockito;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
+ * @todo #135:30min Finish 'getTasksOfContributor()' test case
+ *  when API permits that; as in when a Task can be assigned to a
+ *  Contributor.
  */
 public final class InMemoryTasksTestCase {
 
@@ -108,6 +111,28 @@ public final class InMemoryTasksTestCase {
         final Tasks tasks = storage.tasks()
             .ofProject("mihai/test", "github");
         MatcherAssert.assertThat(tasks, Matchers.contains(registered));
+    }
+
+    /**
+     * Should return contributor's tasks by user name and provider.
+     */
+    @Test
+    public void getTasksOfContributor(){
+        final Storage storage = new InMemory();
+        ProjectManager projectManager = storage
+            .projectManagers().pick("github");
+        final Project project = storage.projects().register(
+            this.mockRepo("mihai/test", "github"), projectManager
+        );
+        final Issue issue = this.mockIssue(
+            "123",
+            project.repoFullName(),
+            project.provider(),
+            Contract.Roles.DEV
+        );
+        storage.tasks().register(issue);
+        storage.tasks().ofContributor("mihai", "github");
+        //incomplete see to-do #134 requirements
     }
 
     /**

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasksTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasksTestCase.java
@@ -131,7 +131,7 @@ public final class InMemoryTasksTestCase {
             Contract.Roles.DEV
         );
         storage.tasks().register(issue);
-        storage.tasks().ofContributor("mihai", "github");
+        //storage.tasks().ofContributor("mihai", "github");
         //incomplete see to-do #134 requirements
     }
 


### PR DESCRIPTION
PR for #141 

Test case for `ofContributor` is incomplete for now.
Added puzzle to update the test case when api permits
assigning a task to a contributor.