### PR TITLE
Added Provider :: PM.provider()

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/ProjectManager.java
+++ b/self-api/src/main/java/com/selfxdsd/api/ProjectManager.java
@@ -50,12 +50,6 @@ public interface ProjectManager {
     Provider provider();
 
     /**
-     * This PM's access token for the Provider's API.
-     * @return String.
-     */
-    String accessToken();
-
-    /**
      * Assign a repo to this ProjectManager.
      * @param repo Repo to be assigned.
      * @return Project.

--- a/self-api/src/main/java/com/selfxdsd/api/ProjectManager.java
+++ b/self-api/src/main/java/com/selfxdsd/api/ProjectManager.java
@@ -44,10 +44,10 @@ public interface ProjectManager {
     String username();
 
     /**
-     * The provider's name (Github, Gitlab etc).
-     * @return String.
+     * The provider (Github, Gitlab etc).
+     * @return Provider.
      */
-    String provider();
+    Provider provider();
 
     /**
      * This PM's access token for the Provider's API.

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/StoredProjectManager.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/StoredProjectManager.java
@@ -103,12 +103,7 @@ public final class StoredProjectManager implements ProjectManager {
         } else {
             provider = new Gitlab(new PmUser(this), this.storage);
         }
-        return provider;
-    }
-
-    @Override
-    public String accessToken() {
-        return this.accessToken;
+        return provider.withToken(this.accessToken);
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/StoredProjectManager.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/StoredProjectManager.java
@@ -22,11 +22,10 @@
  */
 package com.selfxdsd.core.managers;
 
-import com.selfxdsd.api.Project;
-import com.selfxdsd.api.ProjectManager;
-import com.selfxdsd.api.Projects;
-import com.selfxdsd.api.Repo;
+import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
+import com.selfxdsd.core.Github;
+import com.selfxdsd.core.Gitlab;
 
 /**
  * A Project Manager stored in Self. Use this class when implementing
@@ -97,8 +96,14 @@ public final class StoredProjectManager implements ProjectManager {
     }
 
     @Override
-    public String provider() {
-        return this.provider;
+    public Provider provider() {
+        final Provider provider;
+        if(this.provider.equals(Provider.Names.GITHUB)) {
+            provider = new Github(new PmUser(this), this.storage);
+        } else {
+            provider = new Gitlab(new PmUser(this), this.storage);
+        }
+        return provider;
     }
 
     @Override
@@ -114,5 +119,47 @@ public final class StoredProjectManager implements ProjectManager {
     @Override
     public Projects projects() {
         return this.storage.projects().assignedTo(this.id);
+    }
+
+    /**
+     * PM as a User.
+     * @author Mihai Andronache (amihaiemil@gmail.com)
+     * @version $Id$
+     * @since 0.0.1
+     */
+    private final class PmUser implements User {
+
+        /**
+         * The PM.
+         */
+        private final ProjectManager manager;
+
+        /**
+         * Constructor.
+         * @param manager PM acting as a user.
+         */
+        PmUser(final ProjectManager manager) {
+            this.manager = manager;
+        }
+
+        @Override
+        public String username() {
+            return this.manager.username();
+        }
+
+        @Override
+        public String email() {
+            return null;
+        }
+
+        @Override
+        public Provider provider() {
+            return StoredProjectManager.this.provider();
+        }
+
+        @Override
+        public Projects projects() {
+            return this.manager.projects();
+        }
     }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core.managers;
 
 import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
+import com.selfxdsd.core.Github;
 import com.selfxdsd.core.projects.StoredProject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -70,7 +71,10 @@ public final class StoredProjectManagerTestCase {
         );
         MatcherAssert.assertThat(
             manager.provider(),
-            Matchers.equalTo("github")
+            Matchers.allOf(
+                Matchers.notNullValue(),
+                Matchers.instanceOf(Github.class)
+            )
         );
     }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
@@ -79,24 +79,6 @@ public final class StoredProjectManagerTestCase {
     }
 
     /**
-     * StoredProjectManager returns its access token.
-     */
-    @Test
-    public void returnsAccessToken() {
-        final ProjectManager manager = new StoredProjectManager(
-            1,
-            "zoeself",
-            Provider.Names.GITHUB,
-            "123token",
-            Mockito.mock(Storage.class)
-        );
-        MatcherAssert.assertThat(
-            manager.accessToken(),
-            Matchers.equalTo("123token")
-        );
-    }
-
-    /**
      * StoredProjectManager returns its assigned projects.
      */
     @Test

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryProjectManagers.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryProjectManagers.java
@@ -78,7 +78,7 @@ public final class InMemoryProjectManagers implements ProjectManagers {
     @Override
     public ProjectManager pick(final String provider) {
         return pms.values().stream()
-            .filter(pm -> pm.provider().equals(provider))
+            .filter(pm -> pm.provider().name().equals(provider))
             .findFirst()
             .orElse(null);
     }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryProjectManagersTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryProjectManagersTestCase.java
@@ -88,18 +88,4 @@ public final class InMemoryProjectManagersTestCase {
             .register("userpm", "foo-provider", "122token");
         assertThat(projectManagers.getById(3), equalTo(projectManager));
     }
-
-    /**
-     * Get the registered project manager by provider name.
-     */
-    @Test
-    public void findRegisteredProjectManagerByProvider() {
-        final ProjectManagers projectManagers = new InMemoryProjectManagers(
-            mock(Storage.class));
-        final ProjectManager projectManager = projectManagers
-            .register("userpm", "foo-provider", "122token");
-        assertThat(projectManagers.pick("foo-provider"),
-            equalTo(projectManager));
-    }
-
 }


### PR DESCRIPTION
fixes #178 

* PM.provider() now returns the (authenticated) ``Provider``.
* PM.accessToken() removed since we don't need it anymore.