### PR TITLE
#190 Started implementing Invitations for Github

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Invitation.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Invitation.java
@@ -23,58 +23,16 @@
 package com.selfxdsd.api;
 
 /**
- * A Provider is a platform against which the User is authenticated and
- * which holds the User's repos (Github, Gitlab, Bitbucket etc).
+ * Invitation.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 0.0.1
+ * @since 0.0.7
  */
-public interface Provider {
+public interface Invitation {
 
     /**
-     * Name of this provider.
-     * @return String.
+     * Accept this invitation.
      */
-    String name();
+    void accept();
 
-    /**
-     * Get a Repo by its simple name. E.g. "testrepo" is the simple name
-     * of repo "amihaiemil/testrepo".
-     * @param name Simple name of the repo.
-     * @return Repo.
-     */
-    Repo repo(final String name);
-
-    /**
-     * Get the invitations for the authenticated user.
-     * @return Invitations.
-     */
-    Invitations invitations();
-
-    /**
-     * Return a Provider which has an access token.
-     * @param accessToken Access token to make authorized requests with.
-     * @return Provider.
-     */
-    Provider withToken(final String accessToken);
-
-    /**
-     * Names of possible providers.
-     */
-    final class Names {
-        /**
-         * Hidden ctor.
-         */
-        private Names(){ }
-
-        /**
-         * Github provider.
-         */
-        public static final String GITHUB = "github";
-
-        /**
-         * Gitlab provider.
-         */
-        public static final String GITLAB = "gitlab";
-    }
 }

--- a/self-api/src/main/java/com/selfxdsd/api/Invitations.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Invitations.java
@@ -23,58 +23,11 @@
 package com.selfxdsd.api;
 
 /**
- * A Provider is a platform against which the User is authenticated and
- * which holds the User's repos (Github, Gitlab, Bitbucket etc).
+ * Invitations received by a user of a Provider.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 0.0.1
+ * @since 0.0.7
  */
-public interface Provider {
+public interface Invitations extends Iterable<Invitation> {
 
-    /**
-     * Name of this provider.
-     * @return String.
-     */
-    String name();
-
-    /**
-     * Get a Repo by its simple name. E.g. "testrepo" is the simple name
-     * of repo "amihaiemil/testrepo".
-     * @param name Simple name of the repo.
-     * @return Repo.
-     */
-    Repo repo(final String name);
-
-    /**
-     * Get the invitations for the authenticated user.
-     * @return Invitations.
-     */
-    Invitations invitations();
-
-    /**
-     * Return a Provider which has an access token.
-     * @param accessToken Access token to make authorized requests with.
-     * @return Provider.
-     */
-    Provider withToken(final String accessToken);
-
-    /**
-     * Names of possible providers.
-     */
-    final class Names {
-        /**
-         * Hidden ctor.
-         */
-        private Names(){ }
-
-        /**
-         * Github provider.
-         */
-        public static final String GITHUB = "github";
-
-        /**
-         * Gitlab provider.
-         */
-        public static final String GITLAB = "gitlab";
-    }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/BaseRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/BaseRepo.java
@@ -108,7 +108,7 @@ abstract class BaseRepo implements Repo {
                 }
             } catch (final IOException | InterruptedException ex) {
                 throw new IllegalStateException(
-                    "Couldn't fetching repo + [" + this.uri.toString() +"]",
+                    "Couldn't fetch repo + [" + this.uri.toString() +"]",
                     ex
                 );
             }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/Github.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/Github.java
@@ -22,6 +22,7 @@
  */
 package com.selfxdsd.core;
 
+import com.selfxdsd.api.Invitations;
 import com.selfxdsd.api.Provider;
 import com.selfxdsd.api.Repo;
 import com.selfxdsd.api.storage.Storage;
@@ -108,6 +109,21 @@ public final class Github implements Provider {
             this.uri.toString() + "/repos/" + this.user.username() + "/" + name
         );
         return new GithubRepo(this.user, repo, this.storage);
+    }
+
+    @Override
+    public Invitations invitations() {
+        if(this.accessToken == null || this.accessToken.isEmpty()) {
+            throw new IllegalStateException(
+                "Can't fetch invitations without a user's access token"
+            );
+        }
+        return new GithubRepoInvitations(
+            URI.create(
+                this.uri.toString() + "/user/repository_invitations"
+            ),
+            this.accessToken
+        );
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/Github.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/Github.java
@@ -37,6 +37,10 @@ import java.net.URI;
  * @todo #26:30min Bring in Gizzly mock HTTP Server (see jcabi-http),
  *  so we can mock the Github server and write unit tests for the methods
  *  that perform HTTP Requests.
+ * @todo #190:30min Abstract all the HTTP calls behind an implementation of
+ *  an interface called JsonResources. JsonResources will have a runtime
+ *  implementation called HttpJsonResources and a mock implementation used
+ *  for unit testing.
  */
 public final class Github implements Provider {
 
@@ -115,7 +119,7 @@ public final class Github implements Provider {
     public Invitations invitations() {
         if(this.accessToken == null || this.accessToken.isEmpty()) {
             throw new IllegalStateException(
-                "Can't fetch invitations without a user's access token"
+                "Can't fetch invitations without a user's access token."
             );
         }
         return new GithubRepoInvitations(

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepoInvitations.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepoInvitations.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Invitation;
+import com.selfxdsd.api.Invitations;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Iterator;
+
+/**
+ * Github Repo invitations.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.7
+ */
+final class GithubRepoInvitations implements Invitations {
+
+    /**
+     * API uri for the repo invitations.
+     */
+    private final URI repoInvitationsUri;
+
+    /**
+     * User access token.
+     */
+    private final String accessToken;
+
+    /**
+     * Ctor.
+     * @param repoInvitationsUri API uri.
+     * @param accessToken User access token.
+     */
+    GithubRepoInvitations(
+        final URI repoInvitationsUri,
+        final String accessToken
+    ) {
+        this.repoInvitationsUri = repoInvitationsUri;
+        this.accessToken = accessToken;
+    }
+
+    @Override
+    public Iterator<Invitation> iterator() {
+        final JsonArray invitations = this.fetchInvitations();
+        return null;
+    }
+
+    /**
+     * Fetch invitations.
+     * @return JsonArray.
+     */
+    private JsonArray fetchInvitations() {
+        try {
+            final HttpResponse<String> response = HttpClient.newHttpClient()
+                .send(
+                    HttpRequest.newBuilder()
+                        .uri(this.repoInvitationsUri)
+                        .header("Content-Type", "application/json")
+                        .headers("Authorization", "token " + this.accessToken)
+                        .build(),
+                    HttpResponse.BodyHandlers.ofString()
+                );
+            final int status = response.statusCode();
+            if(status == HttpURLConnection.HTTP_OK) {
+                return Json.createReader(
+                    new StringReader(response.body())
+                ).readArray();
+            } else {
+                throw new IllegalStateException(
+                    "Unexpected response when fetching ["
+                  + this.repoInvitationsUri +"]. "
+                  + "Expected 200 OK, but got " + status + "."
+                );
+            }
+        } catch (final IOException | InterruptedException ex) {
+            throw new IllegalStateException(
+                "Couldn't fetch invitations + ["
+              + this.repoInvitationsUri.toString() +"]",
+                ex
+            );
+        }
+    }
+}

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepoInvitations.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepoInvitations.java
@@ -41,6 +41,9 @@ import java.util.Iterator;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.7
+ * @todo #190:30min Add an implementation of interface Invitation,
+ *  called GithubInvitation, which will take the invitation's JSON
+ *  and work with it.
  */
 final class GithubRepoInvitations implements Invitations {
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/Gitlab.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/Gitlab.java
@@ -22,6 +22,7 @@
  */
 package com.selfxdsd.core;
 
+import com.selfxdsd.api.Invitations;
 import com.selfxdsd.api.Provider;
 import com.selfxdsd.api.Repo;
 import com.selfxdsd.api.User;
@@ -105,6 +106,11 @@ public final class Gitlab implements Provider {
     public Repo repo(final String name) {
         final URI repo = URI.create(this.uri.toString() + "/projects/" + name);
         return new GitlabRepo(this.user, repo, this.storage);
+    }
+
+    @Override
+    public Invitations invitations() {
+        throw new UnsupportedOperationException("Not yet implemented.");
     }
 
     @Override


### PR DESCRIPTION
Fixes #190 

Implemented Invitations for Github.
Left puzzle to continue with ``GithubInvitation``.
Left puzzle to abstract the HTTP calls under an interface called ``JsonResources``.