### PR TITLE
#226 started implementing JdkHttp JsonResources

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/Gitlab.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/Gitlab.java
@@ -45,9 +45,14 @@ public final class Gitlab implements Provider {
     private final User user;
 
     /**
-     * Gitlab's URI.
+     * Github's URI.
      */
-    private final URI uri;
+    private final URI uri = URI.create("https://gitlab.com/api/v4");
+
+    /**
+     * Github's JSON Resources.
+     */
+    private final JsonResources resources;
 
     /**
      * Storage where we might save some stuff.
@@ -66,17 +71,21 @@ public final class Gitlab implements Provider {
      * @param storage Storage where we might save some stuff.
      */
     public Gitlab(final User user, final Storage storage) {
-        this(user, storage, URI.create("https://gitlab.com/api/v4"));
+        this(user, storage, new JsonResources.JdkHttp());
     }
 
     /**
      * Constructor.
      * @param user Authenticated user.
      * @param storage Storage where we might save some stuff.
-     * @param uri Base URI of Gitlab's API.
+     * @param resources Gitlab's JSON Resources.
      */
-    public Gitlab(final User user, final Storage storage, final URI uri) {
-        this(user, storage, uri, "");
+    public Gitlab(
+        final User user,
+        final Storage storage,
+        final JsonResources resources
+    ) {
+        this(user, storage, resources, "");
     }
 
     /**
@@ -84,15 +93,17 @@ public final class Gitlab implements Provider {
      * to return an instance which has a token.
      * @param user Authenticated user.
      * @param storage Storage where we might save some stuff.
-     * @param uri Base URI of Gitlab's API.
+     * @param resources Gitlab's JSON Resources.
      * @param accessToken Access token.
      */
     private Gitlab(
-        final User user, final Storage storage,
-        final URI uri, final String accessToken
+        final User user,
+        final Storage storage,
+        final JsonResources resources,
+        final String accessToken
     ) {
         this.user = user;
-        this.uri = uri;
+        this.resources = resources;
         this.storage = storage;
         this.accessToken = accessToken;
     }
@@ -105,7 +116,12 @@ public final class Gitlab implements Provider {
     @Override
     public Repo repo(final String name) {
         final URI repo = URI.create(this.uri.toString() + "/projects/" + name);
-        return new GitlabRepo(this.user, repo, this.storage);
+        return new GitlabRepo(
+            this.resources,
+            repo,
+            this.user,
+            this.storage
+        );
     }
 
     @Override
@@ -115,6 +131,11 @@ public final class Gitlab implements Provider {
 
     @Override
     public Provider withToken(final String accessToken) {
-        return new Gitlab(this.user, this.storage, this.uri, accessToken);
+        return new Gitlab(
+            this.user,
+            this.storage,
+            this.resources,
+            accessToken
+        );
     }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepo.java
@@ -39,17 +39,19 @@ final class GitlabRepo extends BaseRepo {
 
     /**
      * Constructor.
-     * @param owner Owner of this repo.
+     * @param resources Gitlab's JSON Resources.
      * @param uri URI Pointing to this repo.
+     * @param owner Owner of this repo.
      * @param storage Storage used to save the Project when
      *  this repo is activated.
      */
     GitlabRepo(
-        final User owner,
+        final JsonResources resources,
         final URI uri,
+        final User owner,
         final Storage storage
     ) {
-        super(owner, uri, storage);
+        super(resources, uri, owner, storage);
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+/**
+ * JSON Resources used by the Provider.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.8
+ * @todo #226:30min Add other methods such as post, patch etc
+ *  and continue abstracting the HTTP calls away from the Provider's
+ *  implementations (Issues, Comments etc). After that is done, we
+ *  should add a mock implementation of JsonResources, which we will
+ *  use in writing unit tests for the providers.
+ * @todo #226:30min Bring in Grizzly in-memory HTTP Server (see project
+ *  jcabi-github), so we can write integration tests for class JdkHttp.
+ */
+interface JsonResources {
+
+    /**
+     * Get the Resource at the specified URI.
+     * @param uri Resource location.
+     * @return Resource.
+     */
+    Resource get(final URI uri);
+
+    /**
+     * JSON Resources obtained by making HTTP calls, using
+     * the JDK.
+     */
+    final class JdkHttp implements JsonResources {
+        @Override
+        public Resource get(final URI uri) {
+            try {
+                final HttpResponse<String> response = HttpClient.newHttpClient()
+                    .send(
+                        HttpRequest.newBuilder()
+                            .uri(uri)
+                            .header("Content-Type", "application/json")
+                            .build(),
+                        HttpResponse.BodyHandlers.ofString()
+                    );
+                return new Resource() {
+                    @Override
+                    public int statusCode() {
+                        return response.statusCode();
+                    }
+
+                    @Override
+                    public JsonObject asJsonObject() {
+                        return Json.createReader(
+                            new StringReader(response.body())
+                        ).readObject();
+                    }
+
+                    @Override
+                    public JsonArray asJsonArray() {
+                        return Json.createReader(
+                            new StringReader(response.body())
+                        ).readArray();
+                    }
+                };
+            } catch (final IOException | InterruptedException ex) {
+                throw new IllegalStateException(
+                    "Couldn't GET + [" + uri.toString() +"]",
+                    ex
+                );
+            }
+        }
+    }
+}

--- a/self-core-impl/src/main/java/com/selfxdsd/core/Resource.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/Resource.java
@@ -22,58 +22,33 @@
  */
 package com.selfxdsd.core;
 
-import com.selfxdsd.api.Issues;
-import com.selfxdsd.api.Project;
-import com.selfxdsd.api.storage.Storage;
-import com.selfxdsd.api.User;
-import com.selfxdsd.core.issues.GithubIssues;
-
-import java.net.URI;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
 
 /**
- * A Github repository.
+ * Resource returned by the Provider.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 0.0.1
+ * @since 0.0.8
  */
-final class GithubRepo extends BaseRepo {
+interface Resource {
 
     /**
-     * Constructor.
-     * @param resources The provider's JSON Resources.
-     * @param uri URI Pointing to this repo.
-     * @param owner Owner of this repo.
-     * @param storage Storage used to save the Project when
-     *  this repo is activated.
+     * Status code.
+     * @return Integer.
      */
-    GithubRepo(
-        final JsonResources resources,
-        final URI uri,
-        final User owner,
-        final Storage storage
-    ) {
-        super(resources, uri, owner, storage);
-    }
+    int statusCode();
 
-    @Override
-    public Project activate() {
-        return this.storage()
-            .projectManagers()
-            .pick(this.provider())
-            .assign(this);
-    }
+    /**
+     * This resource as JsonObject.
+     * @return JsonObject.
+     */
+    JsonObject asJsonObject();
 
-    @Override
-    public String fullName() {
-        return this.json().getString("full_name");
-    }
-
-    @Override
-    public Issues issues() {
-        return new GithubIssues(
-            URI.create(this.repoUri().toString() + "/issues"),
-            this.storage()
-        );
-    }
+    /**
+     * This resource as JsonArray.
+     * @return JsonArray.
+     */
+    JsonArray asJsonArray();
 
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubRepoTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubRepoTestCase.java
@@ -46,8 +46,9 @@ public final class GithubRepoTestCase {
     public void returnsOwner() {
         final User owner = Mockito.mock(User.class);
         final Repo repo = new GithubRepo(
-            owner,
+            Mockito.mock(JsonResources.class),
             URI.create("http://localhost:8080"),
+            owner,
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(repo.owner(), Matchers.is(owner));

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabRepoTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabRepoTestCase.java
@@ -25,9 +25,10 @@ public final class GitlabRepoTestCase {
     public void returnsOwner() {
         final User owner = Mockito.mock(User.class);
         final Repo repo = new GitlabRepo(
-                owner,
-                URI.create("http://localhost:8080"),
-                Mockito.mock(Storage.class)
+            Mockito.mock(JsonResources.class),
+            URI.create("http://localhost:8080"),
+            owner,
+            Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(repo.owner(), Matchers.is(owner));
     }


### PR DESCRIPTION
Fixes #226 

- Started interface JsonResources with implementing class JdkHttp
- Used it inside Github and Gitlab to abstract the GET Repo call
- Left puzzles to continue with JsonResources methods such as post, patch etc
- Left puzzle for writing integration tests for JsonResources, using Grizzly mock Http Server.