### PR TITLE
#235 JdkHttp Integration Tests with MkGrizzlyContainer

### DIFF
--- a/self-core-impl/pom.xml
+++ b/self-core-impl/pom.xml
@@ -47,6 +47,18 @@
             <version>1.9.5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.jcabi</groupId>
+            <artifactId>jcabi-http</artifactId>
+            <version>1.17</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.grizzly</groupId>
+            <artifactId>grizzly-servlet-webserver</artifactId>
+            <version>1.9.64</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
@@ -42,8 +42,7 @@ import java.net.http.HttpResponse;
  *  implementations (Issues, Comments etc). After that is done, we
  *  should add a mock implementation of JsonResources, which we will
  *  use in writing unit tests for the providers.
- * @todo #226:30min Bring in Grizzly in-memory HTTP Server (see project
- *  jcabi-github), so we can write integration tests for class JdkHttp.
+ *  
  */
 interface JsonResources {
 
@@ -66,6 +65,7 @@ interface JsonResources {
                     .send(
                         HttpRequest.newBuilder()
                             .uri(uri)
+                            .method("GET", HttpRequest.BodyPublishers.noBody())
                             .header("Content-Type", "application/json")
                             .build(),
                         HttpResponse.BodyHandlers.ofString()

--- a/self-core-impl/src/test/java/com/selfxdsd/core/JdkHttpITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/JdkHttpITCase.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import com.jcabi.http.mock.MkAnswer;
+import com.jcabi.http.mock.MkContainer;
+import com.jcabi.http.mock.MkGrizzlyContainer;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+/**
+ * Integration tests for {@link com.selfxdsd.core.JsonResources.JdkHttp}.
+ * We start an in-memory HTTP Server, send the requests and make assertions
+ * on what the queries that the server has received.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.8
+ */
+public final class JdkHttpITCase {
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final RandomPort resource = new RandomPort();
+
+    /**
+     * We can GET a JsonObject from the server with no access token.
+     * @throws IOException If something goes wrong.
+     */
+    @Test
+    public void getJsonObjectOkNoAuth() throws IOException {
+        final JsonObject json = Json.createObjectBuilder()
+            .add("from", "server")
+            .build();
+        try(
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    json.toString()
+                )
+            ).start(this.resource.port())
+        ) {
+            final JsonResources resources = new JsonResources.JdkHttp();
+            final Resource response = resources.get(container.home());
+            MatcherAssert.assertThat(
+                response.asJsonObject(),
+                Matchers.equalTo(json)
+            );
+            MatcherAssert.assertThat(
+                response.statusCode(),
+                Matchers.equalTo(HttpURLConnection.HTTP_OK)
+            );
+        }
+    }
+
+}

--- a/self-core-impl/src/test/java/com/selfxdsd/core/RandomPort.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/RandomPort.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import org.junit.Assume;
+import org.junit.rules.ExternalResource;
+
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import java.io.IOException;
+import java.net.BindException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+
+/**
+ * JUnit rule which finds a free port for integration testing.
+ * If no port is found, the test is skipped.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.8
+ */
+public class RandomPort extends ExternalResource {
+    @Override
+    public final Statement apply(
+        final Statement base, final Description description
+    ) {
+        return new Statement() {
+            @Override
+            // @checkstyle IllegalThrowsCheck (1 line)
+            public void evaluate() throws Throwable {
+                try {
+                    base.evaluate();
+                } catch (final BindException ignored) {
+                    Assume.assumeTrue(false);
+                }
+            }
+        };
+    }
+
+    /**
+     * Returns available port number.
+     * @return Available port number
+     * @throws IOException in case of IO error.
+     */
+    public final int port() throws IOException {
+        final ServerSocket socket = new ServerSocket();
+        try  {
+            socket.setReuseAddress(true);
+            socket.bind(
+                new InetSocketAddress("localhost", 0)
+            );
+            return socket.getLocalPort();
+        } finally {
+            socket.close();
+        }
+    }
+}


### PR DESCRIPTION
PR for #235 

* Used MkGrizzlyContainer (in-memory HTTP Server) to write integration tests for ``JdkHttp``
* For some reason, the JDK http calls to localhost are quite slow (1min/request). It's probably an Issue in the JDK.