### PR TITLE
#239 GithubIssue/s uses JsonResources + made classes package protected

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/BaseRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/BaseRepo.java
@@ -112,6 +112,14 @@ abstract class BaseRepo implements Repo {
     }
 
     /**
+     * Get the JsonResources.
+     * @return JsonResources.
+     */
+    JsonResources resources() {
+        return this.resources;
+    }
+
+    /**
      * Get the URI.
      * @return URI.
      */

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssue.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssue.java
@@ -20,7 +20,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.selfxdsd.core.issues;
+package com.selfxdsd.core;
 
 import com.selfxdsd.api.Contract;
 import com.selfxdsd.api.Issue;
@@ -38,7 +38,7 @@ import java.net.URI;
  *  In a future version, we will set an Issue's role based on labels set
  *  by the user.
  */
-public final class GithubIssue implements Issue {
+final class GithubIssue implements Issue {
 
     /**
      * Issue base uri.
@@ -61,7 +61,7 @@ public final class GithubIssue implements Issue {
      * @param json Json Issue as returned by Github's API.
      * @param storage Storage.
      */
-    public GithubIssue(
+    GithubIssue(
         final URI issueUri,
         final JsonObject json,
         final Storage storage

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepo.java
@@ -26,7 +26,6 @@ import com.selfxdsd.api.Issues;
 import com.selfxdsd.api.Project;
 import com.selfxdsd.api.storage.Storage;
 import com.selfxdsd.api.User;
-import com.selfxdsd.core.issues.GithubIssues;
 
 import java.net.URI;
 
@@ -71,6 +70,7 @@ final class GithubRepo extends BaseRepo {
     @Override
     public Issues issues() {
         return new GithubIssues(
+            this.resources(),
             URI.create(this.repoUri().toString() + "/issues"),
             this.storage()
         );

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssueTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssueTestCase.java
@@ -20,7 +20,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.selfxdsd.core.issues;
+package com.selfxdsd.core;
 
 import com.selfxdsd.api.Contract;
 import com.selfxdsd.api.Issue;

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssuesITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssuesITCase.java
@@ -1,4 +1,4 @@
-package com.selfxdsd.core.issues;
+package com.selfxdsd.core;
 
 import com.selfxdsd.api.Issue;
 import com.selfxdsd.api.Issues;
@@ -28,7 +28,9 @@ public final class GithubIssuesITCase {
     public void fetchesIssueOk(){
         final URI uri = URI.create(
             "https://api.github.com/repos/amihaiemil/docker-java-api/issues");
-        final Issues issues = new GithubIssues(uri, mock(Storage.class));
+        final Issues issues = new GithubIssues(
+            new JsonResources.JdkHttp(), uri, mock(Storage.class)
+        );
         final JsonObject jsonIssue = issues.getById("346").json();
         assertThat("Add Json Suppliers",
             equalTo(jsonIssue.getString("title")));
@@ -43,7 +45,9 @@ public final class GithubIssuesITCase {
     public void fetchesIssueNotFound(){
         final URI uri = URI.create(
             "https://api.github.com/repos/amihaiemil/docker-java-api/issues");
-        final Issues issues = new GithubIssues(uri, mock(Storage.class));
+        final Issues issues = new GithubIssues(
+            new JsonResources.JdkHttp(), uri, mock(Storage.class)
+        );
         final Issue issue = issues.getById("100000");
         assertThat(issue, nullValue());
     }


### PR DESCRIPTION
fixes #239 

* Made GithubIssue/s work with JsonResources instead of making direct HTTP calls
* Mage classes GithubIssues and GithubIssue package protected in the core package -- they should not be visible to the outside.