### PR TITLE
#248 Authenticated JsonResources

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/Github.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/Github.java
@@ -53,15 +53,9 @@ public final class Github implements Provider {
     private final JsonResources resources;
 
     /**
-     * Storge where we might save some stuff.
+     * Storage where we might save some stuff.
      */
     private final Storage storage;
-
-    /**
-     *Token used for making API Requests which require
-     *user authentication.
-     */
-    private final String accessToken;
 
     /**
      * Constructor.
@@ -101,8 +95,7 @@ public final class Github implements Provider {
     ) {
         this.user = user;
         this.storage = storage;
-        this.resources = resources;
-        this.accessToken = accessToken;
+        this.resources = resources.authenticated(accessToken);
     }
 
     @Override
@@ -122,17 +115,11 @@ public final class Github implements Provider {
 
     @Override
     public Invitations invitations() {
-        if(this.accessToken == null || this.accessToken.isEmpty()) {
-            throw new IllegalStateException(
-                "Can't fetch invitations without a user's access token."
-            );
-        }
         return new GithubRepoInvitations(
             this.resources,
             URI.create(
                 this.uri.toString() + "/user/repository_invitations"
-            ),
-            this.accessToken
+            )
         );
     }
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssueComments.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssueComments.java
@@ -53,14 +53,16 @@ public final class GithubIssueComments implements Comments {
     @Override
     public Comment post(final String body) {
         final Resource resource = resources.post(
-                this.commentsUri,
-                Json.createObjectBuilder().add("body", body).build(),
-                "");
+            this.commentsUri,
+            Json.createObjectBuilder().add("body", body).build()
+        );
         if (resource.statusCode() == HttpURLConnection.HTTP_CREATED) {
             return new GithubComment(resource.asJsonObject());
         } else {
-            throw new IllegalStateException("Github Issue Comment "
-                    + "was not created");
+            throw new IllegalStateException(
+                "Github Issue Comment was not created. Status is "
+              + resource.statusCode()
+            );
         }
     }
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepoInvitations.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepoInvitations.java
@@ -38,6 +38,9 @@ import java.util.stream.Collectors;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.7
+ * @todo #248:30min Pass the JsonResources to the GithubInvitation
+ *  as well so we can remove the HTTP calls from there as well.
+ *  Don't forget about testing.
  */
 final class GithubRepoInvitations implements Invitations {
 
@@ -52,24 +55,16 @@ final class GithubRepoInvitations implements Invitations {
     private final URI repoInvitationsUri;
 
     /**
-     * User access token.
-     */
-    private final String accessToken;
-
-    /**
      * Ctor.
      * @param resources Github's JSON resources.
      * @param repoInvitationsUri API uri.
-     * @param accessToken User access token.
      */
     GithubRepoInvitations(
         final JsonResources resources,
-        final URI repoInvitationsUri,
-        final String accessToken
+        final URI repoInvitationsUri
     ) {
         this.resources = resources;
         this.repoInvitationsUri = repoInvitationsUri;
-        this.accessToken = accessToken;
     }
 
     @Override
@@ -79,7 +74,7 @@ final class GithubRepoInvitations implements Invitations {
                 jsonValue -> new GithubInvitation(
                     (JsonObject) jsonValue,
                     this.repoInvitationsUri,
-                    this.accessToken
+                    ""
                 )
             ).collect(Collectors.toList());
         return invitations.iterator();
@@ -91,7 +86,7 @@ final class GithubRepoInvitations implements Invitations {
      */
     private JsonArray fetchInvitations() {
         final Resource invitations = this.resources.get(
-            this.repoInvitationsUri, this.accessToken
+            this.repoInvitationsUri
         );
         if(invitations.statusCode() == HttpURLConnection.HTTP_OK) {
             return invitations.asJsonArray();

--- a/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
@@ -121,7 +121,7 @@ interface JsonResources {
 
         @Override
         public JsonResources authenticated(final String accessToken) {
-            return null;
+            return new JsonResources.JdkHttp(accessToken);
         }
 
         @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
@@ -60,34 +60,19 @@ interface JsonResources {
      * @throws IllegalStateException If IOException or InterruptedException
      *  occur while making the HTTP request.
      */
-    default Resource get(final URI uri) {
-        return this.get(uri, "");
-    }
-
-    /**
-     * Get the Resource at the specified URI.
-     * @param uri Resource location.
-     * @param accessToken Access token for requests that
-     *  require authentication.
-     * @return Resource.
-     * @throws IllegalStateException If IOException or InterruptedException
-     *  occur while making the HTTP request.
-     */
-    Resource get(final URI uri, final String accessToken);
+    Resource get(final URI uri);
 
     /**
      * Post a JsonObject to the specified URI.
      * @param uri URI.
      * @param body JSON body of the request.
-     * @param accessToken Access token for authentication.
      * @return Resource.
      * @throws IllegalStateException If IOException or InterruptedException
      *  occur while making the HTTP request.
      */
     Resource post(
         final URI uri,
-        final JsonObject body,
-        final String accessToken
+        final JsonObject body
     );
 
     /**
@@ -125,7 +110,7 @@ interface JsonResources {
         }
 
         @Override
-        public Resource get(final URI uri, final String accessToken) {
+        public Resource get(final URI uri) {
             try {
                 final HttpResponse<String> response = HttpClient.newHttpClient()
                     .send(
@@ -153,8 +138,7 @@ interface JsonResources {
         @Override
         public Resource post(
             final URI uri,
-            final JsonObject body,
-            final String accessToken
+            final JsonObject body
         ) {
             try {
                 final HttpResponse<String> response = HttpClient.newHttpClient()

--- a/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
@@ -37,14 +37,21 @@ import java.net.http.HttpResponse;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.8
- * @todo #237:30min Add other methods such as delete, patch etc
+ * @todo #248:30min Add other methods such as delete, patch etc
  *  and continue abstracting the HTTP calls away from the Provider's
- *  implementations (Issues, Comments etc). Make sure to offer alternatives
- *  with accessToken as well. After that is done, we should add a mock
- *  implementation of JsonResources, which we will use in writing unit
- *  tests for the providers.
+ *  implementations (Issues, Comments etc). After that is done, we should
+ *  add a mock implementation of JsonResources, which we will use
+ *  in writing unit tests for the providers.
  */
 interface JsonResources {
+
+    /**
+     * Return an instance which has an accessToken for
+     * making authenticated requests.
+     * @param accessToken Access token.
+     * @return JsonResources.
+     */
+    JsonResources authenticated(final String accessToken);
 
     /**
      * Get the Resource at the specified URI.
@@ -91,6 +98,32 @@ interface JsonResources {
      * @since 0.0.8
      */
     final class JdkHttp implements JsonResources {
+
+        /**
+         * Access token.
+         */
+        private final String accessToken;
+
+        /**
+         * Ctor.
+         */
+        JdkHttp() {
+            this("");
+        }
+
+        /**
+         * Ctor.
+         * @param accessToken Access token for authenticated requests.
+         */
+        private JdkHttp(final String accessToken) {
+            this.accessToken = accessToken;
+        }
+
+        @Override
+        public JsonResources authenticated(final String accessToken) {
+            return null;
+        }
+
         @Override
         public Resource get(final URI uri, final String accessToken) {
             try {
@@ -100,8 +133,10 @@ interface JsonResources {
                             .uri(uri)
                             .method("GET", HttpRequest.BodyPublishers.noBody())
                             .header("Content-Type", "application/json")
-                            .header("Authentication", "token " + accessToken)
-                            .build(),
+                            .header(
+                                "Authentication",
+                                "token " + this.accessToken
+                            ).build(),
                         HttpResponse.BodyHandlers.ofString()
                     );
                 return new JsonResponse(
@@ -133,8 +168,10 @@ interface JsonResources {
                                 )
                             )
                             .header("Content-Type", "application/json")
-                            .header("Authentication", "token " + accessToken)
-                            .build(),
+                            .header(
+                                "Authentication",
+                                "token " + this.accessToken
+                            ).build(),
                         HttpResponse.BodyHandlers.ofString()
                     );
                 return new JsonResponse(

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssueCommentsITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssueCommentsITCase.java
@@ -99,8 +99,7 @@ public final class GithubIssueCommentsITCase {
         Mockito
             .when(resources.post(
                 Mockito.any(URI.class),
-                Mockito.any(JsonObject.class),
-                Mockito.anyString()
+                Mockito.any(JsonObject.class)
             ))
             .thenAnswer(invocation -> {
                 final URI uri = ((URI) invocation.getArguments()[0])
@@ -143,8 +142,7 @@ public final class GithubIssueCommentsITCase {
         Mockito
             .when(resources.post(
                 Mockito.any(URI.class),
-                Mockito.any(JsonObject.class),
-                Mockito.anyString()
+                Mockito.any(JsonObject.class)
             ))
             .thenReturn(resource);
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/JdkHttpITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/JdkHttpITCase.java
@@ -28,7 +28,6 @@ import com.jcabi.http.mock.MkGrizzlyContainer;
 import com.jcabi.http.mock.MkQuery;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -93,7 +92,6 @@ public final class JdkHttpITCase {
      * @throws IOException If something goes wrong.
      */
     @Test
-    @Ignore
     public void postJsonObjectWithAuth() throws IOException {
         final JsonObject body = Json.createObjectBuilder()
             .add("test", "post")
@@ -103,9 +101,10 @@ public final class JdkHttpITCase {
                 new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED)
             ).start(this.resource.port())
         ) {
-            final JsonResources resources = new JsonResources.JdkHttp();
+            final JsonResources resources = new JsonResources.JdkHttp()
+                .authenticated("123token456");
             final Resource response = resources.post(
-                container.home(), body, "123token456"
+                container.home(), body
             );
             MatcherAssert.assertThat(
                 response.statusCode(),

--- a/self-core-impl/src/test/java/com/selfxdsd/core/JdkHttpITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/JdkHttpITCase.java
@@ -28,6 +28,7 @@ import com.jcabi.http.mock.MkGrizzlyContainer;
 import com.jcabi.http.mock.MkQuery;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -92,6 +93,7 @@ public final class JdkHttpITCase {
      * @throws IOException If something goes wrong.
      */
     @Test
+    @Ignore
     public void postJsonObjectWithAuth() throws IOException {
         final JsonObject body = Json.createObjectBuilder()
             .add("test", "post")


### PR DESCRIPTION
PR for #248 

Implemented JsonResources :: JsonResources.authenticated(accessToken).
This way, JsonResources encapsulates the accessToken and doesn't expect it as method param, so
we will not have to pass around the token anymore. 