### PR TITLE
#251 GithubInvitation uses JsonResources + fix Authorization header

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubInvitation.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubInvitation.java
@@ -24,12 +24,9 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Invitation;
 
+import javax.json.Json;
 import javax.json.JsonObject;
-import java.io.IOException;
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 
 /**
  * A Github Repo invitation.
@@ -42,9 +39,9 @@ import java.net.http.HttpResponse;
 final class GithubInvitation implements Invitation {
 
     /**
-     * Invitation as JSON.
+     * Github's JSON resources.
      */
-    private final JsonObject json;
+    private final JsonResources resources;
 
     /**
      * URI of this invitation.
@@ -52,26 +49,26 @@ final class GithubInvitation implements Invitation {
     private final URI uri;
 
     /**
-     * Access token.
+     * This invitation as JSON.
      */
-    private final String accessToken;
+    private final JsonObject json;
 
     /**
      * Ctor.
-     * @param json Invitation in JSON format.
+     * @param resources Github's JSON resources.
      * @param baseUri Base URI of the Invitations API.
-     * @param accessToken Access Token.
+     * @param json This invitation in JSON format.
      */
     GithubInvitation(
-        final JsonObject json,
+        final JsonResources resources,
         final URI baseUri,
-        final String accessToken
+        final JsonObject json
     ) {
-        this.json = json;
+        this.resources = resources;
         this.uri = URI.create(
             baseUri.toString() + "/" + json.getJsonNumber("id")
         );
-        this.accessToken = accessToken;
+        this.json = json;
     }
 
     @Override
@@ -81,22 +78,6 @@ final class GithubInvitation implements Invitation {
 
     @Override
     public void accept() {
-        try {
-            HttpClient.newHttpClient()
-                .send(
-                    HttpRequest.newBuilder()
-                        .uri(this.uri)
-                        .method("PATCH", HttpRequest.BodyPublishers.noBody())
-                        .header("Content-Type", "application/json")
-                        .header("Authorization", "token " + this.accessToken)
-                        .build(),
-                    HttpResponse.BodyHandlers.ofString()
-                );
-        } catch (final IOException | InterruptedException ex) {
-            throw new IllegalStateException(
-                "Couldn't accept Invitation + [" + this.uri.toString() + "]",
-                ex
-            );
-        }
+        this.resources.patch(this.uri, Json.createObjectBuilder().build());
     }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepoInvitations.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepoInvitations.java
@@ -38,9 +38,6 @@ import java.util.stream.Collectors;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.7
- * @todo #248:30min Pass the JsonResources to the GithubInvitation
- *  as well so we can remove the HTTP calls from there as well.
- *  Don't forget about testing.
  */
 final class GithubRepoInvitations implements Invitations {
 
@@ -72,9 +69,9 @@ final class GithubRepoInvitations implements Invitations {
         final List<Invitation> invitations = this.fetchInvitations().stream()
             .map(
                 jsonValue -> new GithubInvitation(
-                    (JsonObject) jsonValue,
+                    this.resources,
                     this.repoInvitationsUri,
-                    ""
+                    (JsonObject) jsonValue
                 )
             ).collect(Collectors.toList());
         return invitations.iterator();
@@ -92,7 +89,8 @@ final class GithubRepoInvitations implements Invitations {
             return invitations.asJsonArray();
         } else {
             throw new IllegalStateException(
-                "Unexpected response when fetching [" + this.resources +"]. "
+                "Unexpected response when fetching "
+              + "[" + this.repoInvitationsUri + "]. "
               + "Expected 200 OK, but got " + invitations.statusCode() + "."
             );
         }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
@@ -132,7 +132,7 @@ interface JsonResources {
                             .method("GET", HttpRequest.BodyPublishers.noBody())
                             .header("Content-Type", "application/json")
                             .header(
-                                "Authentication",
+                                "Authorization",
                                 "token " + this.accessToken
                             ).build(),
                         HttpResponse.BodyHandlers.ofString()
@@ -166,7 +166,7 @@ interface JsonResources {
                             )
                             .header("Content-Type", "application/json")
                             .header(
-                                "Authentication",
+                                "Authorization",
                                 "token " + this.accessToken
                             ).build(),
                         HttpResponse.BodyHandlers.ofString()
@@ -201,7 +201,7 @@ interface JsonResources {
                             )
                             .header("Content-Type", "application/json")
                             .header(
-                                "Authentication",
+                                "Authorization",
                                 "token " + this.accessToken
                             ).build(),
                         HttpResponse.BodyHandlers.ofString()

--- a/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
@@ -127,14 +127,11 @@ interface JsonResources {
             try {
                 final HttpResponse<String> response = HttpClient.newHttpClient()
                     .send(
-                        HttpRequest.newBuilder()
-                            .uri(uri)
-                            .method("GET", HttpRequest.BodyPublishers.noBody())
-                            .header("Content-Type", "application/json")
-                            .header(
-                                "Authorization",
-                                "token " + this.accessToken
-                            ).build(),
+                        this.request(
+                            uri,
+                            "GET",
+                            HttpRequest.BodyPublishers.noBody()
+                        ),
                         HttpResponse.BodyHandlers.ofString()
                     );
                 return new JsonResponse(
@@ -156,19 +153,13 @@ interface JsonResources {
             try {
                 final HttpResponse<String> response = HttpClient.newHttpClient()
                     .send(
-                        HttpRequest.newBuilder()
-                            .uri(uri)
-                            .method(
-                                "POST",
-                                HttpRequest.BodyPublishers.ofString(
-                                    body.toString()
-                                )
+                        this.request(
+                            uri,
+                            "POST",
+                            HttpRequest.BodyPublishers.ofString(
+                                body.toString()
                             )
-                            .header("Content-Type", "application/json")
-                            .header(
-                                "Authorization",
-                                "token " + this.accessToken
-                            ).build(),
+                        ),
                         HttpResponse.BodyHandlers.ofString()
                     );
                 return new JsonResponse(
@@ -191,19 +182,13 @@ interface JsonResources {
             try {
                 final HttpResponse<String> response = HttpClient.newHttpClient()
                     .send(
-                        HttpRequest.newBuilder()
-                            .uri(uri)
-                            .method(
-                                "PATCH",
-                                HttpRequest.BodyPublishers.ofString(
-                                    body.toString()
-                                )
+                        this.request(
+                            uri,
+                            "PATCH",
+                            HttpRequest.BodyPublishers.ofString(
+                                body.toString()
                             )
-                            .header("Content-Type", "application/json")
-                            .header(
-                                "Authorization",
-                                "token " + this.accessToken
-                            ).build(),
+                        ),
                         HttpResponse.BodyHandlers.ofString()
                     );
                 return new JsonResponse(
@@ -216,6 +201,38 @@ interface JsonResources {
                     ex
                 );
             }
+        }
+
+        /**
+         * Build and return the HTTP Request.
+         * @param uri URI.
+         * @param method Method.
+         * @param body Body.
+         * @return HttpRequest.
+         */
+        private HttpRequest request(
+            final URI uri,
+            final String method,
+            final HttpRequest.BodyPublisher body
+        ) {
+            final HttpRequest request;
+            if(this.accessToken != null && !this.accessToken.isEmpty()) {
+                request = HttpRequest.newBuilder()
+                    .uri(uri)
+                    .method(method, body)
+                    .header("Content-Type", "application/json")
+                    .header(
+                        "Authorization",
+                        "token " + this.accessToken
+                    ).build();
+            } else {
+                request = HttpRequest.newBuilder()
+                    .uri(uri)
+                    .method(method, body)
+                    .header("Content-Type", "application/json")
+                    .build();
+            }
+            return request;
         }
     }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/JdkHttpITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/JdkHttpITCase.java
@@ -120,7 +120,7 @@ public final class JdkHttpITCase {
                 Matchers.equalTo(body.toString())
             );
             MatcherAssert.assertThat(
-                request.headers().get("Authentication").get(0),
+                request.headers().get("Authorization").get(0),
                 Matchers.equalTo("token 123token456")
             );
         }
@@ -163,7 +163,7 @@ public final class JdkHttpITCase {
                 Matchers.equalTo(body.toString())
             );
             MatcherAssert.assertThat(
-                request.headers().get("Authentication").get(0),
+                request.headers().get("Authorization").get(0),
                 Matchers.equalTo("token 123token456")
             );
         }


### PR DESCRIPTION
PR for #251 

GithubInvitations now uses JsonResources
Bug fix -> "Authorization" header instead of "Authentication".