### PR TITLE
Event interface, Issues.received, Comments.received

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Comments.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Comments.java
@@ -1,5 +1,7 @@
 package com.selfxdsd.api;
 
+import javax.json.JsonObject;
+
 /**
  * Comments related to a particular Provider resource (e.g Issue).
  * @author criske
@@ -17,4 +19,10 @@ public interface Comments extends Iterable<Comment> {
      */
     Comment post(final String body);
 
+    /**
+     * A comment in JSON format received from the Provider.
+     * @param comment Comment in JSON format.
+     * @return Comment.
+     */
+    Comment received(final JsonObject comment);
 }

--- a/self-api/src/main/java/com/selfxdsd/api/Event.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Event.java
@@ -20,58 +20,39 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.selfxdsd.core;
-
-import com.selfxdsd.api.Comment;
-import com.selfxdsd.api.Comments;
-
-import javax.json.JsonObject;
-import java.util.Iterator;
+package com.selfxdsd.api;
 
 /**
- * Comments decorator which makes sure a comment is not posted
- * if it already exists.
+ * Event received from the Provider.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 0.0.8
+ * @since 0.0.9
  */
-final class DoNotRepeat implements Comments {
+public interface Event {
 
     /**
-     * Original comments.
+     * Type of the event.
+     * @return String.
      */
-    private final Comments origin;
+    String type();
 
     /**
-     * Ctor.
-     * @param origin Original comments.
+     * Issue where the event happened.
+     * @return Issue.
      */
-    DoNotRepeat(final Comments origin) {
-        this.origin = origin;
-    }
+    Issue issue();
 
-    @Override
-    public Comment post(final String body) {
-        Comment posted = null;
-        for(final Comment comment : this.origin) {
-            if(comment.body().equalsIgnoreCase(body)) {
-                posted = comment;
-                break;
-            }
-        }
-        if(posted == null) {
-            posted = this.origin.post(body);
-        }
-        return posted;
-    }
+    /**
+     * Comment, present if this event is
+     * related to the Issue's comments (created, deleted etc).
+     * @return Comment.
+     */
+    Comment comment();
 
-    @Override
-    public Comment received(final JsonObject comment) {
-        return this.origin.received(comment);
-    }
+    /**
+     * Project where this event occured.
+     * @return Project.
+     */
+    Project project();
 
-    @Override
-    public Iterator<Comment> iterator() {
-        return this.origin.iterator();
-    }
 }

--- a/self-api/src/main/java/com/selfxdsd/api/Issues.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Issues.java
@@ -22,6 +22,8 @@
  */
 package com.selfxdsd.api;
 
+import javax.json.JsonObject;
+
 /**
  * Issues in a repository.
  * @author Mihai Andronache (amihaiemil@gmail.com)
@@ -37,4 +39,12 @@ public interface Issues extends Iterable<Issue> {
      */
     Issue getById(final String issueId);
 
+    /**
+     * Get an Issue from an existing JsonObject which
+     * Self may receive as part of an event sent
+     * by the Provider.
+     * @param issue The issue's JSON representation.
+     * @return Issue.
+     */
+    Issue received(final JsonObject issue);
 }

--- a/self-api/src/main/java/com/selfxdsd/api/Project.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Project.java
@@ -22,8 +22,6 @@
  */
 package com.selfxdsd.api;
 
-import javax.json.JsonObject;
-
 /**
  * A Project is a User's Repository which has been
  * registered (activated) on the Self platform.
@@ -92,13 +90,13 @@ public interface Project {
 
     /**
      * Resolve the given event that happened in this Project.
-     * @param event JSON event.
+     * @param event Event received from the Provider.
      * @param secret Secret token to make sure the event actually
      *  belongs to this Project.
      * @throws IllegalStateException If the provided secret
      *  is not correct.
      */
-    void resolve(final JsonObject event, final String secret);
+    void resolve(final Event event, final String secret);
 
     /**
      * Deactivate this project, tell  Self to stop

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssueComments.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssueComments.java
@@ -39,8 +39,10 @@ final class GithubIssueComments implements Comments {
      * @param issueUri Comments Issue URI.
      * @param resources Github's JSON Resources.
      */
-    GithubIssueComments(final URI issueUri,
-                               final JsonResources resources) {
+    GithubIssueComments(
+        final URI issueUri,
+        final JsonResources resources
+    ) {
         final String issueUriStr = issueUri.toString();
         String slash = "/";
         if(issueUriStr.endsWith("/")){
@@ -64,6 +66,11 @@ final class GithubIssueComments implements Comments {
               + resource.statusCode()
             );
         }
+    }
+
+    @Override
+    public Comment received(final JsonObject comment) {
+        return new GithubComment(comment);
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssues.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssues.java
@@ -94,9 +94,26 @@ final class GithubIssues implements Issues {
         }
         Issue issue = null;
         if(jsonObject != null){
-            issue = new GithubIssue(issueUri, jsonObject, storage, resources);
+            issue = new GithubIssue(
+                issueUri,
+                jsonObject,
+                this.storage,
+                this.resources
+            );
         }
         return issue;
+    }
+
+    @Override
+    public Issue received(final JsonObject issue) {
+        return new GithubIssue(
+            URI.create(
+                this.issuesUri.toString() + "/" + issue.getInt("number")
+            ),
+            issue,
+            this.storage,
+            this.resources
+        );
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StoredProject.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StoredProject.java
@@ -25,7 +25,6 @@ package com.selfxdsd.core.projects;
 import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
 
-import javax.json.JsonObject;
 import java.util.Objects;
 
 /**
@@ -144,7 +143,7 @@ public final class StoredProject implements Project {
     }
 
     @Override
-    public void resolve(final JsonObject event, final String secret) {
+    public void resolve(final Event event, final String secret) {
         if(!this.webHookToken.equalsIgnoreCase(secret)) {
             throw new IllegalArgumentException(
                 "The provided secret token is not correct!"

--- a/self-core-impl/src/test/java/com/selfxdsd/core/DoNotRepeatTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/DoNotRepeatTestCase.java
@@ -29,6 +29,7 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import javax.json.JsonObject;
 import java.util.Iterator;
 import java.util.List;
 
@@ -109,6 +110,28 @@ public final class DoNotRepeatTestCase {
         MatcherAssert.assertThat(
             comment.body(),
             Matchers.equalTo("new comment")
+        );
+    }
+
+    /**
+     * DoNotRepeat delegates comment receival to origin.
+     */
+    @Test
+    public void receivesComment() {
+        final JsonObject json = Mockito.mock(JsonObject.class);
+        final Comment received = Mockito.mock(Comment.class);
+        Mockito.when(received.json()).thenReturn(json);
+        final Comments origin = Mockito.mock(Comments.class);
+        Mockito.when(origin.received(json)).thenReturn(received);
+
+        final Comments doNotRepeat = new DoNotRepeat(origin);
+        MatcherAssert.assertThat(
+            doNotRepeat.received(json),
+            Matchers.is(received)
+        );
+        MatcherAssert.assertThat(
+            doNotRepeat.received(json).json(),
+            Matchers.is(json)
         );
     }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/StoredProjectTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/StoredProjectTestCase.java
@@ -29,8 +29,6 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import javax.json.JsonObject;
-
 /**
  * Unit tests for {@link StoredProject}.
  * @author Mihai Andronache (amihaiemil@gmail.com)
@@ -72,7 +70,7 @@ public final class StoredProjectTestCase {
             Mockito.mock(ProjectManager.class),
             Mockito.mock(Storage.class)
         );
-        project.resolve(Mockito.mock(JsonObject.class), "wh123wrong");
+        project.resolve(Mockito.mock(Event.class), "wh123wrong");
     }
 
     /**


### PR DESCRIPTION
Fixes #278 

Added the Event interface which represents an Event sent to Self via one of the webhooks.
Added Issues.received to create an Issue from a JsonObject (a webhook event usually has the Issue in json).
Added Comments.received to create a Comment from a JsonObject (a webhook event can contain a comment in json)
Added unit tests
Changed Project.resolve(JsonObject,...) to Project.resolve(Event,...);