### PR TITLE
#317 Invoice.register(Task) + unit tests

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Invoice.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Invoice.java
@@ -10,9 +10,6 @@ import java.time.LocalDateTime;
  * @author criske
  * @version $Id$
  * @since 0.0.3
- * @todo #315:30min An Invoice should have the method #register(Task).
- *  This method should check if the Invoice is active. If it is, register
- *  the Task to the invoice.
  */
 public interface Invoice {
 
@@ -21,6 +18,13 @@ public interface Invoice {
      * @return Integer
      */
     int invoiceId();
+
+    /**
+     * Register a Task on this Invoice.
+     * @param task Task to be registered.
+     * @return InvoicedTask.
+     */
+    InvoicedTask register(final Task task);
 
     /**
      * The contract.

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/StoredInvoice.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/StoredInvoice.java
@@ -1,8 +1,6 @@
 package com.selfxdsd.core.contracts.invoices;
 
-import com.selfxdsd.api.Contract;
-import com.selfxdsd.api.Invoice;
-import com.selfxdsd.api.InvoicedTasks;
+import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
 
 import java.math.BigDecimal;
@@ -90,6 +88,30 @@ public final class StoredInvoice implements Invoice {
     @Override
     public int invoiceId() {
         return this.id;
+    }
+
+    @Override
+    public InvoicedTask register(final Task task) {
+        final Contract.Id taskContract = new Contract.Id(
+            task.project().repoFullName(),
+            task.assignee().username(),
+            task.project().provider(),
+            task.role()
+        );
+        if(!this.contract.contractId().equals(taskContract)) {
+            throw new IllegalArgumentException(
+                "The given Task does not belong to this Invoice!"
+            );
+        } else {
+            if(this.isPaid()) {
+                throw new IllegalStateException(
+                    "Invoice is already paid, can't add a new Task to it!"
+                );
+            }
+            return this.storage.invoicedTasks().register(
+                this, task
+            );
+        }
     }
 
     @Override

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/StoredInvoiceTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/StoredInvoiceTestCase.java
@@ -66,6 +66,126 @@ public final class StoredInvoiceTestCase {
     }
 
     /**
+     * A StoredInvoice will not register a Task which is from
+     * another Contract.
+     */
+    @Test (expected = IllegalArgumentException.class)
+    public void registerRejectsForeignTask() {
+        final Contract contract = Mockito.mock(Contract.class);
+        Mockito.when(contract.contractId()).thenReturn(
+            new Contract.Id(
+                "john/test",
+                "mihai",
+                Provider.Names.GITHUB,
+                Contract.Roles.DEV
+            )
+        );
+        final Invoice invoice = new StoredInvoice(
+            1, contract, LocalDateTime.now(), Mockito.mock(Storage.class)
+        );
+
+        final Project project = Mockito.mock(Project.class);
+        Mockito.when(project.repoFullName()).thenReturn("john/other");
+        Mockito.when(project.provider()).thenReturn(Provider.Names.GITHUB);
+        final Contributor assignee = Mockito.mock(Contributor.class);
+        Mockito.when(assignee.username()).thenReturn("mihai");
+
+        final Task task = Mockito.mock(Task.class);
+        Mockito.when(task.project()).thenReturn(project);
+        Mockito.when(task.assignee()).thenReturn(assignee);
+        Mockito.when(task.role()).thenReturn(Contract.Roles.DEV);
+
+        invoice.register(task);
+    }
+
+    /**
+     * We shouldn't be able to register a new Task if the Invoice
+     * is already paid.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void registerComplainsIfInvoiceIsPaid() {
+        final Contract contract = Mockito.mock(Contract.class);
+        Mockito.when(contract.contractId()).thenReturn(
+            new Contract.Id(
+                "john/test",
+                "mihai",
+                Provider.Names.GITHUB,
+                Contract.Roles.DEV
+            )
+        );
+        final Invoice invoice = new StoredInvoice(
+            1,
+            contract,
+            LocalDateTime.now(),
+            LocalDateTime.now(),
+            "transactionId123",
+            Mockito.mock(Storage.class)
+        );
+
+        final Project project = Mockito.mock(Project.class);
+        Mockito.when(project.repoFullName()).thenReturn("john/test");
+        Mockito.when(project.provider()).thenReturn(Provider.Names.GITHUB);
+        final Contributor assignee = Mockito.mock(Contributor.class);
+        Mockito.when(assignee.username()).thenReturn("mihai");
+
+        final Task task = Mockito.mock(Task.class);
+        Mockito.when(task.project()).thenReturn(project);
+        Mockito.when(task.assignee()).thenReturn(assignee);
+        Mockito.when(task.role()).thenReturn(Contract.Roles.DEV);
+
+        invoice.register(task);
+    }
+
+    /**
+     * We should be able to register a new Task if the Task and
+     * the Invoice belong to the same Contract and the Invoice
+     * is active (not paid yet).
+     */
+    @Test
+    public void registersNewTask() {
+        final Project project = Mockito.mock(Project.class);
+        Mockito.when(project.repoFullName()).thenReturn("john/test");
+        Mockito.when(project.provider()).thenReturn(Provider.Names.GITHUB);
+        final Contributor assignee = Mockito.mock(Contributor.class);
+        Mockito.when(assignee.username()).thenReturn("mihai");
+
+        final Task task = Mockito.mock(Task.class);
+        Mockito.when(task.project()).thenReturn(project);
+        Mockito.when(task.assignee()).thenReturn(assignee);
+        Mockito.when(task.role()).thenReturn(Contract.Roles.DEV);
+
+        final Contract contract = Mockito.mock(Contract.class);
+        Mockito.when(contract.contractId()).thenReturn(
+            new Contract.Id(
+                "john/test",
+                "mihai",
+                Provider.Names.GITHUB,
+                Contract.Roles.DEV
+            )
+        );
+
+        final Storage storage = Mockito.mock(Storage.class);
+        final Invoice invoice = new StoredInvoice(
+            1,
+            contract,
+            LocalDateTime.now(),
+            storage
+        );
+
+        final InvoicedTask registered = Mockito.mock(InvoicedTask.class);
+        final InvoicedTasks invoicedTasks = Mockito.mock(InvoicedTasks.class);
+        Mockito
+            .when(invoicedTasks.register(invoice, task))
+            .thenReturn(registered);
+        Mockito.when(storage.invoicedTasks()).thenReturn(invoicedTasks);
+
+        MatcherAssert.assertThat(
+            invoice.register(task),
+            Matchers.is(registered)
+        );
+    }
+
+    /**
      * Mocks an {@link InvoiceTask}.
      *
      * @param invoiceId Invoice id.


### PR DESCRIPTION
PR for #317 
An Invoice can now register a Task. It will also check if the Task belongs to the same Contract or if it is paid already (it will complain in both situatons). 
Added unit tests too.