### PR TITLE
#337 Fixed GitlabRepo Uri creation from name.

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepo.java
@@ -71,7 +71,7 @@ final class GitlabRepo extends BaseRepo {
                                      final User owner,
                                      final Storage storage) {
         final URI repo = URI.create("https://gitlab.com/api/v4/projects/"
-            + repoName);
+            + owner.username() + "%2F"+repoName);
         return new GitlabRepo(resources, repo, owner, storage);
     }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabITCase.java
@@ -28,7 +28,7 @@ public final class GitlabITCase {
     @Test
     public void fetchesRepoOk() {
         final Provider gitlab = createGitlab("criske");
-        final JsonObject jsonRepo = gitlab.repo("18889648").json();
+        final JsonObject jsonRepo = gitlab.repo("test2").json();
         assertThat(jsonRepo.getInt("id"), equalTo(18889648));
         assertThat(jsonRepo.getString("path_with_namespace"),
             equalTo("criske/test2"));


### PR DESCRIPTION
- also fixed Gitlab integration tests to fetch repo by name instead of by id.

Fixes #337 