### PR TITLE
#333 Provider.repo(name) -> Provider.repo(owner, name)

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Provider.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Provider.java
@@ -38,12 +38,12 @@ public interface Provider {
     String name();
 
     /**
-     * Get a Repo by its simple name. E.g. "testrepo" is the simple name
-     * of repo "amihaiemil/testrepo".
+     * Get a Repo.
+     * @param owner Login of the User owner or Organization name.
      * @param name Simple name of the repo.
      * @return Repo.
      */
-    Repo repo(final String name);
+    Repo repo(final String owner, final String name);
 
     /**
      * Get the invitations for the authenticated user.

--- a/self-core-impl/src/main/java/com/selfxdsd/core/Github.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/Github.java
@@ -107,9 +107,9 @@ public final class Github implements Provider {
     }
 
     @Override
-    public Repo repo(final String name) {
+    public Repo repo(final String owner, final String name) {
         final URI repo = URI.create(
-            this.uri.toString() + "/repos/" + this.user.username() + "/" + name
+            this.uri.toString() + "/repos/" + owner + "/" + name
         );
         return new GithubRepo(
             this.resources, repo, this.user, this.storage

--- a/self-core-impl/src/main/java/com/selfxdsd/core/Gitlab.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/Gitlab.java
@@ -111,8 +111,10 @@ public final class Gitlab implements Provider {
     }
 
     @Override
-    public Repo repo(final String name) {
-        return GitlabRepo.createFromName(name,
+    public Repo repo(final String owner, final String name) {
+        return GitlabRepo.createFromName(
+            owner,
+            name,
             this.resources,
             this.user,
             this.storage);

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabOrganizationRepos.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabOrganizationRepos.java
@@ -82,11 +82,20 @@ final class GitlabOrganizationRepos implements Repos {
      *
      * @param repoData Repo as JSON.
      * @return Repo.
+     * @todo #333:30min The method Provider.repo(name) has been changed to
+     *  Provider.repo(owner, name), where owner is either the User's login
+     *  or the Organization's name. This change was necessary because it's
+     *  not correct to assume that the User is always the actual owner --
+     *  a repo can also be owned by an Organization. In this task, figure out
+     *  what value needs to be passed bellow (currently, we always pass empty
+     *  string).
      */
     private Repo buildRepo(final JsonValue repoData) {
         final String repoName = ((JsonObject) repoData)
             .getString("path");
-        return GitlabRepo.createFromName(repoName,
+        return GitlabRepo.createFromName(
+            "",
+            repoName,
             this.resources,
             this.owner,
             this.storage);

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepo.java
@@ -58,18 +58,22 @@ final class GitlabRepo extends BaseRepo {
     /**
      * Creates a Gitlab Repo from name.
      * @param resources Gitlab's JSON Resources.
+     * @param login Owner's login (Username or Org name).
      * @param repoName Repository name.
      * @param owner Owner of this repo.
      * @param storage Storage used to save the Project when
      *  this repo is activated.
      * @return GitlabRepo.
      */
-    static GitlabRepo createFromName(final String repoName,
-                                     final JsonResources resources,
-                                     final User owner,
-                                     final Storage storage) {
+    static GitlabRepo createFromName(
+        final String login,
+        final String repoName,
+        final JsonResources resources,
+        final User owner,
+        final Storage storage
+    ) {
         final URI repo = URI.create("https://gitlab.com/api/v4/projects/"
-            + owner.username() + "%2F"+repoName);
+            + login + "%2F"+repoName);
         return new GitlabRepo(resources, repo, owner, storage);
     }
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StoredProject.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StoredProject.java
@@ -113,6 +113,7 @@ public final class StoredProject implements Project {
     @Override
     public Repo repo() {
         return this.owner.provider().repo(
+            this.repoFullName.substring(0, this.repoFullName.indexOf("/")),
             this.repoFullName.substring(this.repoFullName.indexOf("/") + 1)
         );
     }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubCollaboratorsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubCollaboratorsTestCase.java
@@ -86,7 +86,7 @@ public final class GithubCollaboratorsTestCase {
             )
         );
         final boolean res = provider
-            .repo("repo")
+            .repo("amihaiemil", "repo")
             .collaborators()
             .invite("mihai", "manage");
         MatcherAssert.assertThat(
@@ -139,7 +139,7 @@ public final class GithubCollaboratorsTestCase {
             )
         );
         final boolean res = provider
-            .repo("repo")
+            .repo("amihaiemil", "repo")
             .collaborators()
             .invite("mihai", "manage");
         MatcherAssert.assertThat(
@@ -192,7 +192,7 @@ public final class GithubCollaboratorsTestCase {
             )
         );
         final boolean res = provider
-            .repo("repo")
+            .repo("amihaiemil", "repo")
             .collaborators()
             .invite("mihai", "manage");
         MatcherAssert.assertThat(

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubITCase.java
@@ -51,7 +51,9 @@ public final class GithubITCase {
         final User user = Mockito.mock(User.class);
         Mockito.when(user.username()).thenReturn("amihaiemil");
         final Provider github = new Github(user, null);
-        final JsonObject repo = github.repo("docker-java-api").json();
+        final JsonObject repo = github
+            .repo("amihaiemil", "docker-java-api")
+            .json();
         MatcherAssert.assertThat(
             repo.getString("name"),
             Matchers.equalTo("docker-java-api")
@@ -71,7 +73,7 @@ public final class GithubITCase {
         Mockito.when(user.username()).thenReturn("amihaiemil");
         final Provider github = new Github(user, null);
         try {
-            github.repo("docker-java-apsi").json();
+            github.repo("amihaiemil", "docker-java-apsi").json();
             Assert.fail("IllegalStateException was expected.");
         } catch (final IllegalStateException ex) {
             MatcherAssert.assertThat(
@@ -105,7 +107,9 @@ public final class GithubITCase {
         );
 
         final Provider github = new Github(user, storage);
-        final Project assigned = github.repo("docker-java-api").activate();
+        final Project assigned = github
+            .repo("amihaiemil", "docker-java-api")
+            .activate();
         MatcherAssert.assertThat(
             assigned.projectManager().id(),
             Matchers.equalTo(1)

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCollaboratorsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCollaboratorsTestCase.java
@@ -83,7 +83,7 @@ public final class GitlabCollaboratorsTestCase {
             )
         );
         final boolean res = provider
-            .repo("repo")
+            .repo("amihaiemil", "repo")
             .collaborators()
             .invite("1234", "30");
         MatcherAssert.assertThat(
@@ -133,7 +133,7 @@ public final class GitlabCollaboratorsTestCase {
             )
         );
         final boolean res = provider
-            .repo("repo")
+            .repo("amihaiemil", "repo")
             .collaborators()
             .invite("1234", "30");
         MatcherAssert.assertThat(
@@ -183,7 +183,7 @@ public final class GitlabCollaboratorsTestCase {
             )
         );
         final boolean res = provider
-            .repo("repo")
+            .repo("amihaiemil", "repo")
             .collaborators()
             .invite("534534", "30");
         MatcherAssert.assertThat(

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabITCase.java
@@ -28,7 +28,7 @@ public final class GitlabITCase {
     @Test
     public void fetchesRepoOk() {
         final Provider gitlab = createGitlab("criske");
-        final JsonObject jsonRepo = gitlab.repo("test2").json();
+        final JsonObject jsonRepo = gitlab.repo("criske", "test2").json();
         assertThat(jsonRepo.getInt("id"), equalTo(18889648));
         assertThat(jsonRepo.getString("path_with_namespace"),
             equalTo("criske/test2"));
@@ -39,7 +39,7 @@ public final class GitlabITCase {
      */
     @Test(expected = IllegalStateException.class)
     public void fetchesRepoNotFound() {
-        createGitlab("criske").repo("1231312123").json();
+        createGitlab("criske").repo("criske", "1231312123").json();
     }
 
     /**

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
@@ -369,6 +369,7 @@ public final class StoredProjectManagerTestCase {
         Mockito.when(repo.issues()).thenReturn(issues);
         Mockito.when(
             prov.repo(
+                fullName.substring(0, fullName.indexOf("/")),
                 fullName.substring(fullName.indexOf("/") + 1)
             )
         ).thenReturn(repo);

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/StoredProjectTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/StoredProjectTestCase.java
@@ -105,13 +105,13 @@ public final class StoredProjectTestCase {
         final Repo repo = Mockito.mock(Repo.class);
         final Provider prov = Mockito.mock(Provider.class);
         Mockito.when(prov.name()).thenReturn(Provider.Names.GITHUB);
-        Mockito.when(prov.repo("test")).thenReturn(repo);
+        Mockito.when(prov.repo("john", "test")).thenReturn(repo);
         final User owner = Mockito.mock(User.class);
         Mockito.when(owner.provider()).thenReturn(prov);
 
         final Project project = new StoredProject(
             owner,
-            "jogn/test",
+            "john/test",
             "wh123token",
             Mockito.mock(ProjectManager.class),
             Mockito.mock(Storage.class)


### PR DESCRIPTION
Fixes #333 
The method now accepts the owner as well - it was not correct to assume that the owner was always the authenticated User, since the owner can also be an Organization.