### PR TITLE
#361 resolve ACTIVATE event + unit tests

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Event.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Event.java
@@ -60,4 +60,21 @@ public interface Event {
      * @return String.
      */
     String provider();
+
+    /**
+     * Event types.
+     */
+    final class Type {
+
+        /**
+         * Hidden ctor.
+         */
+        private Type(){}
+
+        /**
+         * Activate repo event.
+         */
+        public static final String ACTIVATE = "activate";
+
+    }
 }

--- a/self-api/src/main/java/com/selfxdsd/api/ProjectManager.java
+++ b/self-api/src/main/java/com/selfxdsd/api/ProjectManager.java
@@ -69,6 +69,12 @@ public interface ProjectManager {
     Projects projects();
 
     /**
+     * Handle the "activate" (new project registered) event.
+     * @param event Event.
+     */
+    void newProject(final Event event);
+
+    /**
      * Handle the "newIssue" event.
      * @param event Event.
      */

--- a/self-core-impl/src/main/java/com/selfxdsd/core/BaseRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/BaseRepo.java
@@ -128,7 +128,12 @@ abstract class BaseRepo implements Repo {
     }
 
     @Override
-    public abstract Project activate();
+    public Project activate() {
+        return this.storage()
+            .projectManagers()
+            .pick(provider())
+            .assign(this);
+    }
 
     @Override
     public String provider() {

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepo.java
@@ -54,10 +54,40 @@ final class GithubRepo extends BaseRepo {
 
     @Override
     public Project activate() {
-        return this.storage()
-            .projectManagers()
-            .pick(this.provider())
-            .assign(this);
+        final Project project = super.activate();
+        project.resolve(
+            new Event() {
+                @Override
+                public String type() {
+                    return Type.ACTIVATE;
+                }
+
+                @Override
+                public Issue issue() {
+                    throw new UnsupportedOperationException(
+                        "No Issue in the activate event"
+                    );
+                }
+
+                @Override
+                public Comment comment() {
+                    throw new UnsupportedOperationException(
+                        "No Comment in the activate event"
+                    );
+                }
+
+                @Override
+                public Project project() {
+                    return project;
+                }
+
+                @Override
+                public String provider() {
+                    return Provider.Names.GITHUB;
+                }
+            }
+        );
+        return project;
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepo.java
@@ -78,7 +78,40 @@ final class GitlabRepo extends BaseRepo {
 
     @Override
     public Project activate() {
-        return this.storage().projectManagers().pick(provider()).assign(this);
+        final Project project = super.activate();
+        project.resolve(
+            new Event() {
+                @Override
+                public String type() {
+                    return Type.ACTIVATE;
+                }
+
+                @Override
+                public Issue issue() {
+                    throw new UnsupportedOperationException(
+                        "No Issue in the activate event"
+                    );
+                }
+
+                @Override
+                public Comment comment() {
+                    throw new UnsupportedOperationException(
+                        "No Comment in the activate event"
+                    );
+                }
+
+                @Override
+                public Project project() {
+                    return project;
+                }
+
+                @Override
+                public String provider() {
+                    return Provider.Names.GITLAB;
+                }
+            }
+        );
+        return project;
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/StoredProjectManager.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/StoredProjectManager.java
@@ -23,9 +23,12 @@
 package com.selfxdsd.core.managers;
 
 import com.selfxdsd.api.*;
+import com.selfxdsd.api.pm.Step;
 import com.selfxdsd.api.storage.Storage;
 import com.selfxdsd.core.Github;
 import com.selfxdsd.core.Gitlab;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
 
@@ -43,6 +46,13 @@ import java.util.UUID;
  *  We should also add unit tests for class PmUser.
  */
 public final class StoredProjectManager implements ProjectManager {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(
+        StoredProjectManager.class
+    );
 
     /**
      * This PMs id.
@@ -140,6 +150,20 @@ public final class StoredProjectManager implements ProjectManager {
     @Override
     public Projects projects() {
         return this.storage.projects().assignedTo(this.id);
+    }
+
+    @Override
+    public void newProject(final Event event) {
+        final Step steps = new InvitePm(
+            new SetupWebhook(
+                lastly -> LOG.debug(
+                    "Finished setting up project "
+                    + event.project().repoFullName() + " at "
+                    + event.provider()
+                )
+            )
+        );
+        steps.perform(event);
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StoredProject.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StoredProject.java
@@ -146,7 +146,9 @@ public final class StoredProject implements Project {
 
     @Override
     public void resolve(final Event event) {
-        if(event.type().equals("newIssue")) {
+        if(Event.Type.ACTIVATE.equals(event.type())) {
+            this.projectManager.newProject(event);
+        } else if(event.type().equals("newIssue")) {
             this.projectManager.newIssue(event);
         } else if(event.type().equals("reopened")) {
             this.projectManager.reopenedIssue(event);

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubITCase.java
@@ -22,11 +22,8 @@
  */
 package com.selfxdsd.core;
 
-import com.selfxdsd.api.Project;
 import com.selfxdsd.api.Provider;
-import com.selfxdsd.api.storage.Storage;
 import com.selfxdsd.api.User;
-import com.selfxdsd.core.mock.InMemory;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -81,48 +78,6 @@ public final class GithubITCase {
                 Matchers.startsWith("Unexpected response when fetching")
             );
         }
-    }
-
-    /**
-     * A repo can be activated and assigned to a ProjectManager.
-     * The InMemory storage comes with a pre-registered
-     * ProjectManager who has the id 1.
-     */
-    @Test
-    public void activatesRepo() {
-        final Provider provider = Mockito.mock(Provider.class);
-        Mockito.when(provider.name()).thenReturn("github");
-        final User user = Mockito.mock(User.class);
-        Mockito.when(user.provider()).thenReturn(provider);
-        Mockito.when(user.username()).thenReturn("amihaiemil");
-        final Storage storage = new InMemory();
-
-        MatcherAssert.assertThat(
-            storage.projects(),
-            Matchers.iterableWithSize(0)
-        );
-        MatcherAssert.assertThat(
-            storage.projects().assignedTo(1),
-            Matchers.iterableWithSize(0)
-        );
-
-        final Provider github = new Github(user, storage);
-        final Project assigned = github
-            .repo("amihaiemil", "docker-java-api")
-            .activate();
-        MatcherAssert.assertThat(
-            assigned.projectManager().id(),
-            Matchers.equalTo(1)
-        );
-
-        MatcherAssert.assertThat(
-            storage.projects(),
-            Matchers.iterableWithSize(1)
-        );
-        MatcherAssert.assertThat(
-            storage.projects().assignedTo(1),
-            Matchers.iterableWithSize(1)
-        );
     }
 
     /**

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubRepoTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubRepoTestCase.java
@@ -22,9 +22,8 @@
  */
 package com.selfxdsd.core;
 
-import com.selfxdsd.api.Repo;
+import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
-import com.selfxdsd.api.User;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -92,5 +91,38 @@ public final class GithubRepoTestCase {
                 Matchers.instanceOf(GithubWebhooks.class)
             )
         );
+    }
+
+    /**
+     * A GithubRepo can be activated.
+     */
+    @Test
+    public void canBeActivated() {
+        final Project activated = Mockito.mock(Project.class);
+
+        final ProjectManager manager = Mockito.mock(ProjectManager.class);
+        final ProjectManagers all = Mockito.mock(ProjectManagers.class);
+        Mockito.when(all.pick(Provider.Names.GITHUB)).thenReturn(manager);
+        final Storage storage = Mockito.mock(Storage.class);
+        Mockito.when(storage.projectManagers()).thenReturn(all);
+
+        final User owner = Mockito.mock(User.class);
+        final Provider provider = Mockito.mock(Provider.class);
+        Mockito.when(provider.name()).thenReturn(Provider.Names.GITHUB);
+        Mockito.when(owner.provider()).thenReturn(provider);
+
+        final Repo repo = new GithubRepo(
+            Mockito.mock(JsonResources.class),
+            URI.create("http://localhost:8080/repos/mihai/test/"),
+            owner,
+            storage
+        );
+
+        Mockito.when(manager.assign(repo)).thenReturn(activated);
+
+        Project project = repo.activate();
+
+        MatcherAssert.assertThat(project, Matchers.is(activated));
+        Mockito.verify(project, Mockito.times(1)).resolve(Mockito.any());
     }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabRepoTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabRepoTestCase.java
@@ -1,7 +1,6 @@
 package com.selfxdsd.core;
 
-import com.selfxdsd.api.Repo;
-import com.selfxdsd.api.User;
+import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -31,6 +30,39 @@ public final class GitlabRepoTestCase {
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(repo.owner(), Matchers.is(owner));
+    }
+
+    /**
+     * A GitlabRepo can be activated.
+     */
+    @Test
+    public void canBeActivated() {
+        final Project activated = Mockito.mock(Project.class);
+
+        final ProjectManager manager = Mockito.mock(ProjectManager.class);
+        final ProjectManagers all = Mockito.mock(ProjectManagers.class);
+        Mockito.when(all.pick(Provider.Names.GITLAB)).thenReturn(manager);
+        final Storage storage = Mockito.mock(Storage.class);
+        Mockito.when(storage.projectManagers()).thenReturn(all);
+
+        final User owner = Mockito.mock(User.class);
+        final Provider provider = Mockito.mock(Provider.class);
+        Mockito.when(provider.name()).thenReturn(Provider.Names.GITLAB);
+        Mockito.when(owner.provider()).thenReturn(provider);
+
+        final Repo repo = new GitlabRepo(
+            Mockito.mock(JsonResources.class),
+            URI.create("http://localhost:8080/repos/mihai/test/"),
+            owner,
+            storage
+        );
+
+        Mockito.when(manager.assign(repo)).thenReturn(activated);
+
+        Project project = repo.activate();
+
+        MatcherAssert.assertThat(project, Matchers.is(activated));
+        Mockito.verify(project, Mockito.times(1)).resolve(Mockito.any());
     }
 
 }


### PR DESCRIPTION
fixes #361 

* GithubRepo and GitlabRepo pass on the "activate" Event to the registered project
* Event is resolved and handled by the PM (using InvitePm and SetupWebhook steps)
* Created Event.Type class of constants
* Added unit tests for both GithubRepo.activate and GitlabRepo.activate
* Removed superficial integration test.