### PR TITLE
#431. Implemented+tested Task::unassign().

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Task.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Task.java
@@ -65,6 +65,12 @@ public interface Task {
     Task assign(final Contributor contributor);
 
     /**
+     * Unassign this Task.
+     * @return The unassigned task.
+     */
+    Task unassign();
+
+    /**
      * When was this Task assigned?
      * @return LocalDateTime.
      */

--- a/self-api/src/main/java/com/selfxdsd/api/Tasks.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Tasks.java
@@ -60,6 +60,13 @@ public interface Tasks extends Iterable<Task> {
     Task assign(final Task task, final Contract contract, final int days);
 
     /**
+     * Unassign a Task.
+     * @param task Task to be unassigned.
+     * @return Task.
+     */
+    Task unassign(Task task);
+
+    /**
      * Get the tasks of a given Project.
      * @param repoFullName Full name of the Repo that the Project represents.
      * @param repoProvider Provider of the Repo that the Project represents.
@@ -91,5 +98,4 @@ public interface Tasks extends Iterable<Task> {
      * @return Tasks.
      */
     Tasks unassigned();
-
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContractTasks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContractTasks.java
@@ -123,4 +123,15 @@ public final class ContractTasks implements Tasks {
     ) {
         return this.storage.tasks().assign(task, contract, days);
     }
+
+    @Override
+    public Task unassign(final Task task) {
+        final boolean isOfContract = this.tasks.get()
+            .anyMatch(t -> t.equals(task));
+        if (!isOfContract) {
+            throw new IllegalStateException("This task is not part of"
+                + " contract with id " + this.contractId);
+        }
+        return this.storage.tasks().unassign(task);
+    }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContributorTasks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContributorTasks.java
@@ -85,6 +85,18 @@ public final class ContributorTasks implements Tasks {
     }
 
     @Override
+    public Task unassign(final Task task) {
+        final boolean isOfContributor = task.assignee() != null
+            && task.assignee().username().equals(this.username)
+            && task.assignee().provider().equals(this.provider);
+        if (!isOfContributor) {
+            throw new IllegalStateException("This task was not assigned to"
+                + " this contributor " + this.username + "/" + this.provider);
+        }
+        return this.storage.tasks().unassign(task);
+    }
+
+    @Override
     public Tasks ofProject(final String repoFullName,
                            final String repoProvider) {
         final Supplier<Stream<Task>> ofProject = () -> tasks.get()
@@ -104,7 +116,7 @@ public final class ContributorTasks implements Tasks {
         }
         throw new IllegalStateException(
             "Already seeing the tasks of a Contributor. "
-          + "You cannot see the tasks of another Contributor here."
+                + "You cannot see the tasks of another Contributor here."
         );
     }
 
@@ -114,9 +126,10 @@ public final class ContributorTasks implements Tasks {
             .get()
             .filter(
                 t -> t.project().repoFullName().equals(id.getRepoFullName())
-            && t.project().provider().equals(id.getProvider())
-            && t.assignee().username().endsWith(id.getContributorUsername())
-            && t.role().equals(id.getRole()));
+                    && t.project().provider().equals(id.getProvider())
+                    && t.assignee().username()
+                    .endsWith(id.getContributorUsername())
+                    && t.role().equals(id.getRole()));
         return new ContractTasks(id, tasksOf, this.storage);
 
     }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ProjectTasks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ProjectTasks.java
@@ -121,6 +121,19 @@ public final class ProjectTasks implements Tasks {
     }
 
     @Override
+    public Task unassign(final Task task) {
+        final boolean isOfProject = task.project().repoFullName()
+            .equals(this.repoFullName) && task.project().provider()
+            .equals(this.provider);
+        if (!isOfProject) {
+            throw new IllegalStateException("This task is not part of the"
+                + " project " + this.repoFullName + " with provider "
+                + this.provider);
+        }
+        return this.storage.tasks().unassign(task);
+    }
+
+    @Override
     public Tasks ofProject(
         final String repoFullName,
         final String repoProvider

--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/StoredTask.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/StoredTask.java
@@ -35,8 +35,6 @@ import java.util.Objects;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
- * @todo #427:30min Implement and test method Task::Task.unassign().
- *  This method should remove the assignee and leave the Task unassigned.
  */
 public final class StoredTask implements Task {
 
@@ -168,6 +166,17 @@ public final class StoredTask implements Task {
             );
         }
         return this.storage.tasks().assign(this, contract, 10);
+    }
+
+    @Override
+    public Task unassign() {
+        final Task task;
+        if(this.assignee() == null){
+            task = this;
+        }else {
+            task = this.storage.tasks().unassign(this);
+        }
+        return task;
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/UnassignedTasks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/UnassignedTasks.java
@@ -69,6 +69,12 @@ public final class UnassignedTasks implements Tasks {
     }
 
     @Override
+    public Task unassign(final Task task) {
+        throw new UnsupportedOperationException("Can't unassign a task from "
+            + "UnassignedTasks. These tasks are already unassigned.");
+    }
+
+    @Override
     public Tasks ofProject(final String repoFullName,
                            final String repoProvider) {
         final Supplier<Stream<Task>> ofProject = () -> tasks.get()

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasks.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasks.java
@@ -130,6 +130,24 @@ public final class InMemoryTasks implements Tasks {
     }
 
     @Override
+    public Task unassign(final Task task) {
+        final TaskKey key = new TaskKey(
+            task.issue().issueId(),
+            task.project().repoFullName(),
+            task.project().provider()
+        );
+        final Task unassigned = new StoredTask(
+            task.project(),
+            key.issueId,
+            task.role(),
+            task.estimation(),
+            this.storage
+        );
+        this.tasks.put(key, unassigned);
+        return unassigned;
+    }
+
+    @Override
     public Tasks ofProject(final String repoFullName,
                            final String repoProvider) {
         final Supplier<Stream<Task>> tasksOf = () -> tasks.values()

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasksTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasksTestCase.java
@@ -37,8 +37,8 @@ import org.mockito.Mockito;
  * @todo #135:30min Finish 'getTasksOfContributor()' test case
  *  when API permits that; as in when a Task can be assigned to a
  *  Contributor.
- * @todo #439:30min Test assign and unassign Task using the in-memory
- *  implementation of {@link Storage}.
+ * @todo #439:30min Update InMemoryTasks assign() and unassign()
+ *  to use Task#issueId() then test them.
  */
 public final class InMemoryTasksTestCase {
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasksTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasksTestCase.java
@@ -37,6 +37,8 @@ import org.mockito.Mockito;
  * @todo #135:30min Finish 'getTasksOfContributor()' test case
  *  when API permits that; as in when a Task can be assigned to a
  *  Contributor.
+ * @todo #439:30min Test assign and unassign Task using the in-memory
+ *  implementation of {@link Storage}.
  */
 public final class InMemoryTasksTestCase {
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/tasks/ContractTasksTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/tasks/ContractTasksTestCase.java
@@ -236,4 +236,40 @@ public final class ContractTasksTestCase {
         Mockito.verify(all, Mockito.times(1)).assign(task, contract, days);
     }
 
+    /**
+     * Throws ISE when unasssigning Task is not part of ContractTasks.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void throwsWhenUnassigningTaskNotPartOfContract(){
+        final Task task = Mockito.mock(Task.class);
+        final Tasks tasks = new ContractTasks(
+            new Contract.Id("foo", "mihai",
+                "github", "dev"),
+            () -> Stream.of(task),
+            Mockito.mock(Storage.class)
+        );
+
+        tasks.unassign(Mockito.mock(Task.class));
+    }
+
+    /**
+     * An assigned Task part of ContractTasks can be unassigned.
+     */
+    @Test
+    public void canBeUnassignedIfPartOfContract(){
+        final Task task = Mockito.mock(Task.class);
+        final Storage storage = Mockito.mock(Storage.class);
+        final Tasks tasks = new ContractTasks(
+            new Contract.Id("foo", "mihai",
+                "github", "dev"),
+            () -> Stream.of(task),
+            storage
+        );
+
+        Mockito.when(storage.tasks()).thenReturn(Mockito.mock(Tasks.class));
+
+        tasks.unassign(task);
+        Mockito.verify(storage.tasks()).unassign(task);
+    }
+
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/tasks/ContributorTasksTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/tasks/ContributorTasksTestCase.java
@@ -239,6 +239,49 @@ public final class ContributorTasksTestCase {
     }
 
     /**
+     * Throws ISE when unasssigning Task is not part of ContributorTasks.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void throwsWhenUnassigningTaskNotPartOfContributorTasks(){
+        final Task task = Mockito.mock(Task.class);
+        final Contributor contributor = Mockito.mock(Contributor.class);
+        final Tasks tasks = new ContributorTasks(
+            "mihai", "github",
+            () -> Stream.of(task),
+            Mockito.mock(Storage.class)
+        );
+
+        Mockito.when(contributor.username()).thenReturn("mihai");
+        Mockito.when(contributor.provider()).thenReturn("github");
+        Mockito.when(task.assignee()).thenReturn(contributor);
+
+        tasks.unassign(Mockito.mock(Task.class));
+    }
+
+    /**
+     * An assigned Task part of ContributorTasks can be unassigned.
+     */
+    @Test
+    public void canBeUnassignedIfPartOfContributorTasks(){
+        final Storage storage = Mockito.mock(Storage.class);
+        final Task task = Mockito.mock(Task.class);
+        final Contributor contributor = Mockito.mock(Contributor.class);
+        final Tasks tasks = new ContributorTasks(
+            "mihai", "github",
+            () -> Stream.of(task),
+            storage
+        );
+
+        Mockito.when(contributor.username()).thenReturn("mihai");
+        Mockito.when(contributor.provider()).thenReturn("github");
+        Mockito.when(task.assignee()).thenReturn(contributor);
+        Mockito.when(storage.tasks()).thenReturn(Mockito.mock(Tasks.class));
+
+        tasks.unassign(task);
+        Mockito.verify(storage.tasks()).unassign(task);
+    }
+
+    /**
      * Mock an Issue for test.
      *
      * @param issueId ID.

--- a/self-core-impl/src/test/java/com/selfxdsd/core/tasks/ProjectTasksTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/tasks/ProjectTasksTestCase.java
@@ -323,6 +323,57 @@ public final class ProjectTasksTestCase {
         Mockito.verify(all, Mockito.times(1)).assign(task, contract, days);
     }
 
+
+    /**
+     * Throws ISE when unasssigning Task is not part of ProjectTasks.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void throwsWhenUnassigningTaskNotPartOfProjectTasks(){
+        final Task task = Mockito.mock(Task.class);
+        final Task otherTask = Mockito.mock(Task.class);
+        final Project project = Mockito.mock(Project.class);
+        final Project otherProject = Mockito.mock(Project.class);
+        final Tasks tasks = new ProjectTasks(
+            "john/test", "github",
+            () -> Stream.of(task),
+            Mockito.mock(Storage.class)
+        );
+
+        Mockito.when(project.repoFullName()).thenReturn("john/test");
+        Mockito.when(project.provider()).thenReturn("github");
+        Mockito.when(task.project()).thenReturn(project);
+        Mockito.when(otherProject.repoFullName()).thenReturn("john/test-other");
+        Mockito.when(otherProject.provider()).thenReturn("github");
+        Mockito.when(otherTask.project()).thenReturn(otherProject);
+
+        tasks.unassign(otherTask);
+    }
+
+    /**
+     * An assigned Task part of ProjectTasks can be unassigned.
+     */
+    @Test
+    public void canBeUnassignedIfPartOfProjectTasks(){
+        final Storage storage = Mockito.mock(Storage.class);
+        final Task task = Mockito.mock(Task.class);
+        final Project project = Mockito.mock(Project.class);
+        final Tasks tasks = new ProjectTasks(
+            "john/test", "github",
+            () -> Stream.of(task),
+            storage
+        );
+
+        Mockito.when(project.repoFullName()).thenReturn("john/test");
+        Mockito.when(project.provider()).thenReturn("github");
+        Mockito.when(task.project()).thenReturn(project);
+        Mockito.when(storage.tasks()).thenReturn(Mockito.mock(Tasks.class));
+
+        tasks.unassign(task);
+
+        Mockito.verify(storage.tasks()).unassign(task);
+
+    }
+
     /**
      * Mock an Issue for test.
      *

--- a/self-core-impl/src/test/java/com/selfxdsd/core/tasks/StoredTaskTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/tasks/StoredTaskTestCase.java
@@ -452,4 +452,39 @@ public final class StoredTaskTestCase {
             task, contract, 10
         );
     }
+
+    /**
+     * An assigned StoredTask can be unassigned.
+     */
+    @Test
+    public void canBeUnassigned(){
+        final Storage storage = Mockito.mock(Storage.class);
+        final Contributor assignee = Mockito.mock(Contributor.class);
+        final Contract contract = Mockito.mock(Contract.class);
+        final Tasks all = Mockito.mock(Tasks.class);
+        final Task task = new StoredTask(contract, "1", storage,
+            LocalDateTime.now(), LocalDateTime.now().plusDays(2), 60);
+
+        Mockito.when(contract.contributor()).thenReturn(assignee);
+        Mockito.when(storage.tasks()).thenReturn(all);
+        Mockito.when(all.unassign(Mockito.any(Task.class)))
+            .thenReturn(Mockito.mock(Task.class));
+
+        MatcherAssert.assertThat(task.assignee(),
+            Matchers.notNullValue());
+        MatcherAssert.assertThat(task.unassign().assignee(),
+            Matchers.nullValue());
+
+    }
+
+    /**
+     * An unassigned StoredTask returns itself when calling unassign.
+     */
+    @Test
+    public void unassignedTaskReturnsItselfWhenUnassign(){
+        final Task task = new StoredTask(Mockito.mock(Project.class),
+            "1", "DEV", 60, Mockito.mock(Storage.class));
+
+        MatcherAssert.assertThat(task.unassign(), Matchers.equalTo(task));
+    }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/tasks/UnassignedTaskTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/tasks/UnassignedTaskTestCase.java
@@ -183,6 +183,16 @@ public final class UnassignedTaskTestCase {
     }
 
     /**
+     * Throws {@link UnsupportedOperationException} when calling unassign.
+     * Tasks here are already unassigned.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void throwsWhenUnassigningTask(){
+        new UnassignedTasks(Stream::empty, Mockito.mock(Storage.class))
+            .unassign(Mockito.mock(Task.class));
+    }
+
+    /**
      * Mock an Issue for test.
      * @param issueId ID.
      * @param repoFullName Repo fullname.


### PR DESCRIPTION
- added the corespondent method in Tasks Api.
- implemented and tested unassign() for filter Tasks classes.
- left puzzle to test InMemoryTasks#unassign()

PR for #431 