### PR TITLE
#371. Paged Contributors implemented+tested.

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Contributors.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Contributors.java
@@ -62,7 +62,7 @@ public interface Contributors extends Iterable<Contributor>, Paged {
     /**
      * Get the Contributors at the provided Page.
      * @param page Page number.
-     * @return Projects in a page.
+     * @return Contributors in a page.
      */
     Contributors page(final Paged.Page page);
 

--- a/self-api/src/main/java/com/selfxdsd/api/Contributors.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Contributors.java
@@ -22,13 +22,15 @@
  */
 package com.selfxdsd.api;
 
+import com.selfxdsd.api.storage.Paged;
+
 /**
  * Contributors in Self.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
  */
-public interface Contributors extends Iterable<Contributor> {
+public interface Contributors extends Iterable<Contributor>, Paged {
 
     /**
      * Register a new contributor in Self.
@@ -56,6 +58,13 @@ public interface Contributors extends Iterable<Contributor> {
         final String repoFullName,
         final String repoProvider
     );
+
+    /**
+     * Get the Contributors at the provided Page.
+     * @param page Page number.
+     * @return Projects in a page.
+     */
+    Contributors page(final Paged.Page page);
 
     /**
      * Elect a Contributor for the given task.

--- a/self-api/src/main/java/com/selfxdsd/api/storage/Paged.java
+++ b/self-api/src/main/java/com/selfxdsd/api/storage/Paged.java
@@ -6,8 +6,8 @@ package com.selfxdsd.api.storage;
  * @author criske
  * @version $Id$
  * @since 0.0.13
- * @todo #366:30min Provide paging implementation for other Self entities:
- *  Contributors, Contracts, Invoices, InvoicedTasks, Tasks.
+ * @todo #462:30min Provide paging implementation for other Self entities:
+ *  Contracts, Invoices, InvoicedTasks, Tasks.
  *  As guidance use implementation for Projects: Pm/User/InMemoryProjects.
  */
 public interface Paged {
@@ -47,6 +47,14 @@ public interface Paged {
         public Page(final int number, final int size) {
             this.number = number;
             this.size = size;
+        }
+
+        /**
+         * Represents all records in a single page.
+         * @return Page.
+         */
+        public static Page all(){
+            return new Page(1, Integer.MAX_VALUE);
         }
 
         /**

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contributors/ProjectContributorsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contributors/ProjectContributorsTestCase.java
@@ -22,6 +22,7 @@
 package com.selfxdsd.core.contributors;
 
 import com.selfxdsd.api.*;
+import com.selfxdsd.api.storage.Paged;
 import com.selfxdsd.api.storage.Storage;
 import com.selfxdsd.core.contracts.ContributorContracts;
 import org.hamcrest.MatcherAssert;
@@ -32,6 +33,7 @@ import org.mockito.Mockito;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
@@ -61,6 +63,34 @@ public final class ProjectContributorsTestCase {
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(contributors, Matchers.iterableWithSize(3));
+    }
+
+    /**
+     * ProjectContributors should be iterable by Page.
+     */
+    @Test
+    public void canBeIteratedByPage() {
+        final Contributors contributors = new ProjectContributors(
+            this.mockProject(
+                "john/test",
+                Provider.Names.GITHUB,
+                BigDecimal.valueOf(100000),
+                BigDecimal.valueOf(1000)
+            ),
+            () -> IntStream.rangeClosed(1, 50)
+                .mapToObj( i -> Mockito.mock(Contributor.class)),
+            Mockito.mock(Storage.class)
+        );
+        MatcherAssert.assertThat(contributors, Matchers.iterableWithSize(50));
+        final Contributors pageOne = contributors
+            .page(new Paged.Page(1, 20));
+        MatcherAssert.assertThat(pageOne, Matchers.iterableWithSize(20));
+        final Contributors pageTwo = contributors
+            .page(new Paged.Page(2, 20));
+        MatcherAssert.assertThat(pageTwo, Matchers.iterableWithSize(20));
+        final Contributors pageThree = contributors
+            .page(new Paged.Page(3, 20));
+        MatcherAssert.assertThat(pageThree, Matchers.iterableWithSize(10));
     }
 
     /**

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contributors/ProjectContributorsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contributors/ProjectContributorsTestCase.java
@@ -78,7 +78,7 @@ public final class ProjectContributorsTestCase {
                 BigDecimal.valueOf(1000)
             ),
             () -> IntStream.rangeClosed(1, 50)
-                .mapToObj( i -> Mockito.mock(Contributor.class)),
+                .mapToObj(i -> Mockito.mock(Contributor.class)),
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(contributors, Matchers.iterableWithSize(50));

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryContributorsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryContributorsTestCase.java
@@ -1,6 +1,7 @@
 package com.selfxdsd.core.mock;
 
 import com.selfxdsd.api.*;
+import com.selfxdsd.api.storage.Paged;
 import com.selfxdsd.api.storage.Storage;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -110,6 +111,45 @@ public final class InMemoryContributorsTestCase {
         MatcherAssert.assertThat(
             storage.contributors(),
             Matchers.iterableWithSize(1));
+    }
+
+    /**
+     * Check if iterator is working properly.
+     */
+    @Test
+    public void iteratorWorksByPage() {
+        final Storage storage = new InMemory();
+        for (int i = 1; i <= 50; i++) {
+            storage.contributors()
+                .register("horea".repeat(i), "github");
+        }
+        MatcherAssert.assertThat(
+            storage.contributors(),
+            Matchers.iterableWithSize(50));
+
+        final Contributors pageOne = storage.contributors()
+            .page(new Paged.Page(1, 20));
+        MatcherAssert.assertThat(
+            pageOne,
+            Matchers.iterableWithSize(20));
+        MatcherAssert.assertThat(pageOne.iterator().next().username(),
+            Matchers.equalTo("horea".repeat(1)));
+
+        final Contributors pageTwo = storage.contributors()
+            .page(new Paged.Page(2, 20));
+        MatcherAssert.assertThat(
+            pageTwo,
+            Matchers.iterableWithSize(20));
+        MatcherAssert.assertThat(pageTwo.iterator().next().username(),
+            Matchers.equalTo("horea".repeat(21)));
+
+        final Contributors pageThree = storage.contributors()
+            .page(new Paged.Page(3, 20));
+        MatcherAssert.assertThat(
+            pageThree,
+            Matchers.iterableWithSize(10));
+        MatcherAssert.assertThat(pageThree.iterator().next().username(),
+            Matchers.equalTo("horea".repeat(41)));
     }
 
     /**


### PR DESCRIPTION
- added creator method helper for Page.all representation.
- ProjectContributors is defaulted to `Page.all` as starting page to prevent faulty results in elect() pool.
- InMemoryContributors is now using a TreeMap for table in order to have a better control over its keys in testing.
- updated puzzle

PR for #371