### PR TITLE
#479. Repo#activate() throws RepoAlreadyActiveException if active.

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/exceptions/RepoAlreadyActiveException.java
+++ b/self-api/src/main/java/com/selfxdsd/api/exceptions/RepoAlreadyActiveException.java
@@ -15,7 +15,7 @@ public final class RepoAlreadyActiveException extends RuntimeException {
      * @param repo Repo in question.
      */
     public RepoAlreadyActiveException(final Repo repo){
-        super("Rep \"" + repo.fullName() + "\" is already active.");
+        super("Repo \"" + repo.fullName() + "\" is already active.");
     }
 
 }

--- a/self-api/src/main/java/com/selfxdsd/api/exceptions/RepoAlreadyActiveException.java
+++ b/self-api/src/main/java/com/selfxdsd/api/exceptions/RepoAlreadyActiveException.java
@@ -1,0 +1,21 @@
+package com.selfxdsd.api.exceptions;
+
+import com.selfxdsd.api.Repo;
+
+/**
+ * Exception thrown if we try to active an already active Repo.
+ * @author criske
+ * @version $Id$
+ * @since 0.0.20
+ */
+public final class RepoAlreadyActiveException extends RuntimeException {
+
+    /**
+     * Ctor.
+     * @param repo Repo in question.
+     */
+    public RepoAlreadyActiveException(final Repo repo){
+        super("Rep \"" + repo.fullName() + "\" is already active.");
+    }
+
+}

--- a/self-core-impl/src/main/java/com/selfxdsd/core/BaseRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/BaseRepo.java
@@ -24,8 +24,10 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Project;
 import com.selfxdsd.api.Repo;
-import com.selfxdsd.api.storage.Storage;
 import com.selfxdsd.api.User;
+import com.selfxdsd.api.exceptions.RepoAlreadyActiveException;
+import com.selfxdsd.api.storage.Storage;
+
 import javax.json.JsonObject;
 import java.net.HttpURLConnection;
 import java.net.URI;
@@ -129,6 +131,11 @@ abstract class BaseRepo implements Repo {
 
     @Override
     public Project activate() {
+        final boolean isActive = this.storage().projects()
+            .getProjectById(this.fullName(), this.provider()) != null;
+        if (isActive) {
+            throw new RepoAlreadyActiveException(this);
+        }
         return this.storage()
             .projectManagers()
             .pick(provider())

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepo.java
@@ -110,7 +110,7 @@ final class GitlabRepo extends BaseRepo {
 
     @Override
     public String fullName() {
-        throw new UnsupportedOperationException("Not yet implemented.");
+        return this.json().getString("path_with_namespace");
     }
 
     @Override

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabRepoTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabRepoTestCase.java
@@ -1,11 +1,16 @@
 package com.selfxdsd.core;
 
 import com.selfxdsd.api.*;
+import com.selfxdsd.api.exceptions.RepoAlreadyActiveException;
 import com.selfxdsd.api.storage.Storage;
+import com.selfxdsd.core.mock.InMemory;
+import com.selfxdsd.core.mock.MockJsonResources;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import javax.json.Json;
 import java.net.URI;
 
 /**
@@ -40,18 +45,26 @@ public final class GitlabRepoTestCase {
         final Project activated = Mockito.mock(Project.class);
 
         final ProjectManager manager = Mockito.mock(ProjectManager.class);
-        final ProjectManagers all = Mockito.mock(ProjectManagers.class);
-        Mockito.when(all.pick(Provider.Names.GITLAB)).thenReturn(manager);
+        final ProjectManagers managers = Mockito.mock(ProjectManagers.class);
+        Mockito.when(managers.pick(Provider.Names.GITLAB)).thenReturn(manager);
         final Storage storage = Mockito.mock(Storage.class);
-        Mockito.when(storage.projectManagers()).thenReturn(all);
+        Mockito.when(storage.projectManagers()).thenReturn(managers);
+        Mockito.when(storage.projects())
+            .thenReturn(Mockito.mock(Projects.class));
 
         final User owner = Mockito.mock(User.class);
         final Provider provider = Mockito.mock(Provider.class);
         Mockito.when(provider.name()).thenReturn(Provider.Names.GITLAB);
         Mockito.when(owner.provider()).thenReturn(provider);
 
+        final JsonResources res = new MockJsonResources(request -> {
+            return new MockJsonResources
+                .MockResource(200, Json.createObjectBuilder()
+                .add("path_with_namespace", "mihai/test")
+                .build());
+        });
         final Repo repo = new GitlabRepo(
-            Mockito.mock(JsonResources.class),
+            res,
             URI.create("http://localhost:8080/repos/mihai/test/"),
             owner,
             storage
@@ -63,6 +76,31 @@ public final class GitlabRepoTestCase {
 
         MatcherAssert.assertThat(project, Matchers.is(activated));
         Mockito.verify(project, Mockito.times(1)).resolve(Mockito.any());
+    }
+
+    /**
+     * Throws {@link RepoAlreadyActiveException} if {@link GitlabRepo}  is
+     * already active.
+     */
+    @Test(expected = RepoAlreadyActiveException.class)
+    public void throwsRepoAlreadyActiveExceptionIfActive(){
+        final Storage storage = new InMemory();
+        final User owner = Mockito.mock(User.class);
+        final Provider provider = Mockito.mock(Provider.class);
+        Mockito.when(owner.provider()).thenReturn(provider);
+        Mockito.when(provider.name()).thenReturn(Provider.Names.GITLAB);
+        final JsonResources res = new MockJsonResources(request -> {
+            return new MockJsonResources
+                .MockResource(200, Json.createObjectBuilder()
+                .add("path_with_namespace", "john/test")
+                .build());
+        });
+        final Repo repo = new GitlabRepo(res, URI.create("/"), owner, storage);
+        storage.projects().register(repo,
+            storage.projectManagers().pick(Provider.Names.GITLAB),
+            "token");
+
+        repo.activate();
     }
 
     /**


### PR DESCRIPTION
PR for #479 