### PR TITLE
#491 Simple ctor for SendReply, to ease its usage 

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/Confused.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/Confused.java
@@ -29,8 +29,7 @@ public final class Confused implements Conversation {
                 String.format(
                     event.project().language().reply("misunderstand.comment"),
                     event.comment().author()
-                ),
-                lastly -> LOG.debug("Finished conversation.")
+                )
             );
         } else {
             throw new IllegalStateException("Invalid event type: "

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/Deregister.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/Deregister.java
@@ -72,9 +72,7 @@ public final class Deregister implements Conversation {
                             String.format(
                                 language.reply("deregister.comment"),
                                 author
-                            ),
-                            lastly -> LOG
-                                .debug("Task removed successfully.")
+                            )
                         )
                     )
                 ),
@@ -82,10 +80,6 @@ public final class Deregister implements Conversation {
                     String.format(
                         language.reply("cannotDeregister.comment"),
                         author
-                    ),
-                    lastly -> LOG.debug(
-                        "User " + author + " doesn't have the role to"
-                            + " remove the task."
                     )
                 ), Contract.Roles.PO, Contract.Roles.ARCH
             );

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/Hello.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/Hello.java
@@ -64,8 +64,7 @@ public final class Hello implements Conversation {
                 String.format(
                     event.project().language().reply("hello.comment"),
                     event.comment().author()
-                ),
-                lastly -> LOG.debug("Finished conversation.")
+                )
             );
         } else {
             steps = this.next.start(event);

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/Register.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/Register.java
@@ -72,9 +72,6 @@ public final class Register implements Conversation {
                         String.format(
                             language.reply("taskAlreadyRegistered.comment"),
                             author
-                        ),
-                        lastly -> LOG.debug(
-                            "Task is already registered, not doing anything."
                         )
                     ),
                     new RegisterIssue(
@@ -82,9 +79,6 @@ public final class Register implements Conversation {
                             String.format(
                                 language.reply("taskRegistered.comment"),
                                 author
-                            ),
-                            lastly -> LOG.debug(
-                                "Register conversation ended."
                             )
                         )
                     )
@@ -93,9 +87,6 @@ public final class Register implements Conversation {
                     String.format(
                         language.reply("mustBeContributor.comment"),
                         author
-                    ),
-                    lastly -> LOG.debug(
-                        "Task not registered, author is not a contributor."
                     )
                 ),
                 Contract.Roles.ANY

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/SendReply.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/SendReply.java
@@ -57,7 +57,7 @@ public final class SendReply extends Intermediary {
     public SendReply(final String reply) {
         this(
             reply,
-            lastly -> LOG.debug("Coversation ended.")
+            lastly -> LOG.debug("Conversation ended.")
         );
     }
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/SendReply.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/SendReply.java
@@ -35,11 +35,6 @@ import org.slf4j.LoggerFactory;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.20
- * @todo #489:30min Add a simple constructor which only takes
- *  the String reply and sets a Final next step which only logs
- *  "Conversation ended". Usually, SendReply is the last step
- *  in any Conversation, so this will simplify the code a lot
- *  in most places where SendReply is used.
  */
 public final class SendReply extends Intermediary {
 
@@ -54,6 +49,17 @@ public final class SendReply extends Intermediary {
      * Reply text.
      */
     private final String reply;
+
+    /**
+     * Ctor.
+     * @param reply Reply text.
+     */
+    public SendReply(final String reply) {
+        this(
+            reply,
+            lastly -> LOG.debug("Coversation ended.")
+        );
+    }
 
     /**
      * Ctor.

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/Status.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/Status.java
@@ -94,10 +94,7 @@ public final class Status implements Conversation {
                     task.estimation()
                 );
             }
-            steps = new SendReply(
-                reply,
-                lastly -> LOG.debug("Task status sent successfully.")
-            );
+            steps = new SendReply(reply);
         } else {
             steps = this.notStatus.start(event);
         }


### PR DESCRIPTION
PR for #491 

Added a simple String ctor for SendReply, to clean up the composition where SendReply is being used. Most of the times, SendReply is the last step in any conversation, so a final step logging "Conversation ended" is enough.