### PR TITLE
#516 Removed permission param when inviting Repo Collaborator

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Collaborators.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Collaborators.java
@@ -33,10 +33,9 @@ public interface Collaborators {
     /**
      * Invite a user to be a collaborator.
      * @param username Username.
-     * @param permission Permission level the user will have in the repo.
      * @return True or false, whether the invitations
      *  was successful or not.
      */
-    boolean invite(final String username, final String permission);
+    boolean invite(final String username);
 
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubCollaborators.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubCollaborators.java
@@ -79,21 +79,15 @@ final class GithubCollaborators implements Collaborators {
     }
 
     @Override
-    public boolean invite(
-        final String username,
-        final String permission
-    ) {
+    public boolean invite(final String username) {
         final boolean result;
         LOG.debug(
-            "Inviting user " + username + " with permission ["
-            + permission + "]" + " to ["
-            + this.collaboratorsUri.toString() + "]."
+            "Inviting Collaborator " + username + " with permission "
+            + "to [" + this.collaboratorsUri.toString() + "]."
         );
         final Resource response = this.resources.put(
             URI.create(this.collaboratorsUri.toString() + "/" + username),
-            Json.createObjectBuilder()
-                .add("permission", permission.toLowerCase())
-                .build()
+            Json.createObjectBuilder().build()
         );
         if(response.statusCode() == HttpURLConnection.HTTP_CREATED) {
             result = true;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborators.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborators.java
@@ -64,16 +64,14 @@ public final class GitlabCollaborators implements Collaborators {
      * <a href="https://docs.gitlab.com/ee/api/members.html#valid-access-levels">
      * values </a>
      * @param username User ID.
-     * @param permission Access level the user will have in the repo.
      * @return True or false, whether the invitations was successful or not.
      */
     @Override
-    public boolean invite(final String username, final String permission) {
+    public boolean invite(final String username) {
         final boolean result;
         LOG.debug(
-            "Inviting user " + username + " with access level ["
-                + permission + "]" + " to ["
-                + this.collaboratorsUri.toString() + "]."
+            "Inviting user " + username
+            + " to [" + this.collaboratorsUri.toString() + "]."
         );
         final Resource response = this.resources.post(
                 this.collaboratorsUri,

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/InvitePm.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/InvitePm.java
@@ -25,8 +25,6 @@ package com.selfxdsd.core.managers;
 import com.selfxdsd.api.*;
 import com.selfxdsd.api.pm.Intermediary;
 import com.selfxdsd.api.pm.Step;
-import com.selfxdsd.core.Github;
-import com.selfxdsd.core.Gitlab;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,19 +62,16 @@ public final class InvitePm extends Intermediary {
             "Inviting PM to repo " + repo.fullName() + " at " + provider
         );
         final String user;
-        final String permission;
         if(Provider.Names.GITHUB.equals(provider)) {
             user = manager.username();
-            permission = Github.Permissions.MAINTAIN;
         } else if (Provider.Names.GITLAB.equals(provider)) {
             user = manager.userId();
-            permission = Gitlab.Permissions.MAINTAINER;
         } else {
             throw new IllegalStateException(
                 "Unknown Provider: [" + provider + "]."
             );
         }
-        final boolean response = repo.collaborators().invite(user, permission);
+        final boolean response = repo.collaborators().invite(user);
         if(response) {
             LOG.debug("PM invited successfully!");
         } else {

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubCollaboratorsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubCollaboratorsTestCase.java
@@ -67,7 +67,6 @@ public final class GithubCollaboratorsTestCase {
                         req.getBody(),
                         Matchers.equalTo(
                             Json.createObjectBuilder()
-                                .add("permission", "manage")
                                 .build()
                         )
                     );
@@ -88,7 +87,7 @@ public final class GithubCollaboratorsTestCase {
         final boolean res = provider
             .repo("amihaiemil", "repo")
             .collaborators()
-            .invite("mihai", "manage");
+            .invite("mihai");
         MatcherAssert.assertThat(
             res, Matchers.is(Boolean.TRUE)
         );
@@ -120,7 +119,6 @@ public final class GithubCollaboratorsTestCase {
                         req.getBody(),
                         Matchers.equalTo(
                             Json.createObjectBuilder()
-                                .add("permission", "manage")
                                 .build()
                         )
                     );
@@ -141,7 +139,7 @@ public final class GithubCollaboratorsTestCase {
         final boolean res = provider
             .repo("amihaiemil", "repo")
             .collaborators()
-            .invite("mihai", "manage");
+            .invite("mihai");
         MatcherAssert.assertThat(
             res, Matchers.is(Boolean.TRUE)
         );
@@ -173,7 +171,6 @@ public final class GithubCollaboratorsTestCase {
                         req.getBody(),
                         Matchers.equalTo(
                             Json.createObjectBuilder()
-                                .add("permission", "manage")
                                 .build()
                         )
                     );
@@ -194,7 +191,7 @@ public final class GithubCollaboratorsTestCase {
         final boolean res = provider
             .repo("amihaiemil", "repo")
             .collaborators()
-            .invite("mihai", "manage");
+            .invite("mihai");
         MatcherAssert.assertThat(
             res, Matchers.is(Boolean.FALSE)
         );

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCollaboratorsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCollaboratorsTestCase.java
@@ -85,7 +85,7 @@ public final class GitlabCollaboratorsTestCase {
         final boolean res = provider
             .repo("amihaiemil", "repo")
             .collaborators()
-            .invite("1234", "30");
+            .invite("1234");
         MatcherAssert.assertThat(
             res, Matchers.is(Boolean.TRUE)
         );
@@ -135,7 +135,7 @@ public final class GitlabCollaboratorsTestCase {
         final boolean res = provider
             .repo("amihaiemil", "repo")
             .collaborators()
-            .invite("1234", "30");
+            .invite("1234");
         MatcherAssert.assertThat(
             res, Matchers.is(Boolean.TRUE)
         );
@@ -185,7 +185,7 @@ public final class GitlabCollaboratorsTestCase {
         final boolean res = provider
             .repo("amihaiemil", "repo")
             .collaborators()
-            .invite("534534", "30");
+            .invite("534534");
         MatcherAssert.assertThat(
             res, Matchers.is(Boolean.FALSE)
         );

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/InvitePmTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/InvitePmTestCase.java
@@ -24,8 +24,6 @@ package com.selfxdsd.core.managers;
 
 import com.selfxdsd.api.*;
 import com.selfxdsd.api.pm.Step;
-import com.selfxdsd.core.Github;
-import com.selfxdsd.core.Gitlab;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -67,10 +65,7 @@ public final class InvitePmTestCase {
 
         final Collaborators collaborators = Mockito.mock(Collaborators.class);
         Mockito.when(
-            collaborators.invite(
-                Mockito.anyString(),
-                Mockito.anyString()
-            )
+            collaborators.invite(Mockito.anyString())
         ).thenReturn(true);
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.when(repo.collaborators()).thenReturn(collaborators);
@@ -90,7 +85,7 @@ public final class InvitePmTestCase {
         Mockito.verify(
             collaborators,
             Mockito.times(1)
-        ).invite("123", Gitlab.Permissions.MAINTAINER);
+        ).invite("123");
         Mockito.verify(
             next,
             Mockito.times(1)
@@ -108,10 +103,7 @@ public final class InvitePmTestCase {
 
         final Collaborators collaborators = Mockito.mock(Collaborators.class);
         Mockito.when(
-            collaborators.invite(
-                Mockito.anyString(),
-                Mockito.anyString()
-            )
+            collaborators.invite(Mockito.anyString())
         ).thenReturn(true);
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.when(repo.collaborators()).thenReturn(collaborators);
@@ -131,7 +123,7 @@ public final class InvitePmTestCase {
         Mockito.verify(
             collaborators,
             Mockito.times(1)
-        ).invite("zoeself", Github.Permissions.MAINTAIN);
+        ).invite("zoeself");
         Mockito.verify(
             next,
             Mockito.times(1)


### PR DESCRIPTION
Fixes #516 
The ``permission`` parameter is only applicable for orgs -- if it's a user repo, the request will fail with ``422 UNPROCESSABLE ENTITY``. Since the default permission level is ``push`` (which is good enough), we removed this parameter.