### PR TITLE
#525 Issues.open(title, body, labels) implemented and tested

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Issue.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Issue.java
@@ -29,9 +29,8 @@ import javax.json.JsonObject;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
- * @todo #97:30min Implement Comments::Issue.comments(). This method
- *  should be the entry point to an Issue's comments and have methods for
- *  both listing and posting new comments.
+ * @todo #525:30min Implement method Issue.close() which should
+ *  use the "Update Issue" endpoint to close it.
  */
 public interface Issue {
 

--- a/self-api/src/main/java/com/selfxdsd/api/Issues.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Issues.java
@@ -47,4 +47,17 @@ public interface Issues extends Iterable<Issue> {
      * @return Issue.
      */
     Issue received(final JsonObject issue);
+
+    /**
+     * Open a new Issue.
+     * @param title Title of the Issue.
+     * @param body Text body.
+     * @param labels Labels to attach to the Issue.
+     * @return The opened Issue.
+     */
+    Issue open(
+        final String title,
+        final String body,
+        final String... labels
+    );
 }


### PR DESCRIPTION
Fixes #525  
Also added the option to specify labels for the newly opened Issue (Github will create the labels if they do not exist).
Left puzzle to implement ``Issue.close()``.