### PR TITLE
#541 PayoutMethod.json() implemented and tested

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/PayoutMethod.java
+++ b/self-api/src/main/java/com/selfxdsd/api/PayoutMethod.java
@@ -22,6 +22,8 @@
  */
 package com.selfxdsd.api;
 
+import javax.json.JsonObject;
+
 /**
  * A Contributor's payout method, how Self is going to
  * send them money.
@@ -54,6 +56,13 @@ public interface PayoutMethod {
      * @return String.
      */
     String identifier();
+
+    /**
+     * The whole PayoutMethod in JSON.
+     * This usually comes from the API of the payment processor.
+     * @return The PayoutMethod in JSON format.
+     */
+    JsonObject json();
 
     /**
      * Possible payout methods.

--- a/self-core-impl/pom.xml
+++ b/self-core-impl/pom.xml
@@ -34,6 +34,15 @@
             <artifactId>stripe-java</artifactId>
             <version>20.3.2</version>
         </dependency>
+        <!--
+            Required because stripe-java only declares it with runtime scope
+            and we need it with compile scope so we can use the returned gson JsonObjects
+        -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.6</version>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contributors/StripePayoutMethodTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contributors/StripePayoutMethodTestCase.java
@@ -26,6 +26,7 @@ import com.selfxdsd.api.Contributor;
 import com.selfxdsd.api.PayoutMethod;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -100,5 +101,30 @@ public final class StripePayoutMethodTestCase {
             method.identifier(),
             Matchers.equalTo("acct_001")
         );
+    }
+
+    /**
+     * StoredContributor.json() should throw an ISE
+     * if the stripe.api.token env variable is not set.
+     */
+    @Test
+    public void jsonComplainsOnMissingApiKey() {
+        final PayoutMethod method = new StripePayoutMethod(
+            Mockito.mock(Contributor.class),
+            "acct_001",
+            Boolean.TRUE
+        );
+
+        try {
+            method.json();
+            Assert.fail("IllegalStateException was expected.");
+        } catch (final IllegalStateException ex) {
+            MatcherAssert.assertThat(
+                ex.getMessage(),
+                Matchers.equalTo(
+                    "Please specify the stripe.api.token Environment Variable!"
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
PR for #541 

Instead of offering just an accessor method for the ``onboarding`` flag, we decided to offer an accessor method for the whole ``javax.json.JsonObject``, representing the whole PayoutMethod/Account, because we will need more information than just that flag and we want to avoid multiple useless API calls.