### PR TITLE
#564. StoredProjectManager#assignedTasks handle missing task deadline

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssueComments.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssueComments.java
@@ -57,7 +57,7 @@ final class GithubIssueComments implements Comments {
         if(issueUriStr.endsWith("/")){
             slash = "";
         }
-        this.commentsUri = URI.create(issueUriStr + slash + "comments");
+        this.commentsUri = URI.create(issueUriStr + slash + "comments/");
         this.resources = resources;
     }
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssueComments.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssueComments.java
@@ -57,7 +57,7 @@ final class GithubIssueComments implements Comments {
         if(issueUriStr.endsWith("/")){
             slash = "";
         }
-        this.commentsUri = URI.create(issueUriStr + slash + "comments/");
+        this.commentsUri = URI.create(issueUriStr + slash + "comments");
         this.resources = resources;
     }
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/StoredProjectManager.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/StoredProjectManager.java
@@ -43,6 +43,9 @@ import java.util.function.Supplier;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
+ * @todo #571:30min When checking if task deadline is missed in
+ *  assignedTasks(...), we should take into account the hours and minutes
+ *  as well. Right now we checking it against days left.
  * @checkstyle ExecutableStatementCount (500 lines)
  */
 public final class StoredProjectManager implements ProjectManager {

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssueCommentsITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssueCommentsITCase.java
@@ -17,6 +17,8 @@ import java.net.URI;
  * @author criske
  * @version $Id$
  * @since 0.0.8
+ * @todo #572:15min Fix failing GithubIssueComments tests due to trailing "/"
+ *  of issue comments uri.
  */
 public final class GithubIssueCommentsITCase {
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssueCommentsITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssueCommentsITCase.java
@@ -17,8 +17,6 @@ import java.net.URI;
  * @author criske
  * @version $Id$
  * @since 0.0.8
- * @todo #572:15min Fix failing GithubIssueComments tests due to trailing "/"
- *  of issue comments uri.
  */
 public final class GithubIssueCommentsITCase {
 
@@ -29,7 +27,7 @@ public final class GithubIssueCommentsITCase {
     @Test
     public void iteratesIssueComments(){
         final URI issueUri = URI.create(
-            "https://api.github.com/repos/octocat/Hello-World/issues/1/"
+            "https://api.github.com/repos/octocat/Hello-World/issues/1"
         );
         final JsonResources resources = Mockito.mock(JsonResources.class);
 
@@ -40,12 +38,12 @@ public final class GithubIssueCommentsITCase {
                 final JsonArray array = Json.createArrayBuilder()
                     .add(Json.createObjectBuilder()
                         .add("id", 1)
-                        .add("url", uri.resolve("1").toString())
+                        .add("url", uri.toString() + "/1")
                         .add("body", "Comment issue #1")
                         .build())
                     .add(Json.createObjectBuilder()
                         .add("id", 2)
-                        .add("url", uri.resolve("2").toString())
+                        .add("url", uri.toString() + "/2")
                         .add("body", "Comment issue #2")
                         .build())
                     .build();
@@ -64,7 +62,7 @@ public final class GithubIssueCommentsITCase {
         MatcherAssert.assertThat(firstComment.body(),
             Matchers.equalTo("Comment issue #1"));
         MatcherAssert.assertThat(firstComment.json().getString("url"),
-            Matchers.equalTo(issueUri.resolve("comments/1").toString()));
+            Matchers.equalTo(issueUri.toString() + "/comments/1"));
     }
 
     /**
@@ -73,7 +71,7 @@ public final class GithubIssueCommentsITCase {
     @Test
     public void iteratesNothingIfIssueCommentsNotFound(){
         final URI issueUri = URI.create(
-            "https://api.github.com/repos/octocat/Hello-World/issues/1/"
+            "https://api.github.com/repos/octocat/Hello-World/issues/1"
         );
         final JsonResources resources = Mockito.mock(JsonResources.class);
         final Resource resource = buildResource(404, null, null);
@@ -92,7 +90,7 @@ public final class GithubIssueCommentsITCase {
     @Test
     public void postsIssueCommentOk() {
         final URI issueUri = URI.create(
-            "https://api.github.com/repos/octocat/Hello-World/issues/1/"
+            "https://api.github.com/repos/octocat/Hello-World/issues/1"
         );
         final JsonResources resources = Mockito.mock(JsonResources.class);
         final Comments issueComments =
@@ -104,8 +102,8 @@ public final class GithubIssueCommentsITCase {
                 Mockito.any(JsonObject.class)
             ))
             .thenAnswer(invocation -> {
-                final URI uri = ((URI) invocation.getArguments()[0])
-                    .resolve("1");
+                final URI uri = URI.create(invocation.getArguments()[0]
+                    .toString() + "/1");
                 final String body = ((JsonObject) invocation
                     .getArguments()[1]).getString("body");
                 final JsonObject object = Json.createObjectBuilder()
@@ -124,7 +122,7 @@ public final class GithubIssueCommentsITCase {
         MatcherAssert.assertThat(comment.body(),
             Matchers.equalTo("Comment issue #1"));
         MatcherAssert.assertThat(comment.json().getString("url"),
-            Matchers.equalTo(issueUri.resolve("comments/1").toString()));
+            Matchers.equalTo(issueUri.toString() +"/comments/1"));
     }
 
     /**
@@ -134,7 +132,7 @@ public final class GithubIssueCommentsITCase {
     @Test(expected = IllegalStateException.class)
     public void throwsIfCommentNotCreated() {
         final URI issueUri = URI.create(
-            "https://api.github.com/repos/octocat/Hello-World/issues/1/"
+            "https://api.github.com/repos/octocat/Hello-World/issues/1"
         );
         final JsonResources resources = Mockito.mock(JsonResources.class);
         final Comments issueComments =

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
@@ -898,7 +898,9 @@ public final class StoredProjectManagerTestCase {
         Mockito.verify(comments, Mockito.times(1))
             .post("@mihai Looks like you've missed the task deadline ("
                 + deadlineDate.toString() + "). "
-                + "You are now resigned from this task.");
+                + "You are now resigned from this task.\n\n"
+                + "Please stop working on it, you will not be paid. "
+                + "I will assign it to someone else soon.");
     }
 
     /**

--- a/self-core-impl/src/test/resources/responses_en.properties
+++ b/self-core-impl/src/test/resources/responses_en.properties
@@ -36,4 +36,5 @@ taskInvoiced.comment=@%s thank you for resolving this ticket. I've just added it
                      check all your invoices and more on the [Contributor Dashboard](https://self-xdsd.com).
 taskDeadlineReminder.comment=@%s Don't forget to close this ticket before the deadline (%s). You are past the first half \
                              of the allowed period.
-taskDeadlineMissed.comment=@%s Looks like you've missed the task deadline (%s). You are now resigned from this task.
+taskDeadlineMissed.comment=@%s Looks like you've missed the task deadline (%s). You are now resigned from this task.\n\n\
+                           Please stop working on it, you will not be paid. I will assign it to someone else soon.

--- a/self-core-impl/src/test/resources/responses_en.properties
+++ b/self-core-impl/src/test/resources/responses_en.properties
@@ -36,3 +36,4 @@ taskInvoiced.comment=@%s thank you for resolving this ticket. I've just added it
                      check all your invoices and more on the [Contributor Dashboard](https://self-xdsd.com).
 taskDeadlineReminder.comment=@%s Don't forget to close this ticket before the deadline (%s). You are past the first half \
                              of the allowed period.
+taskDeadlineMissed.comment=@%s Looks like you've missed the task deadline (%s). You are now resigned from this task.


### PR DESCRIPTION
- added test for this use case.
- added test for deadline reminder.
- ~~re-added "slash" at the end of `commentsUri` in GithubIssueComments ctor. Without it, some
GithubIssueComments tests fail (Uri#resolve used in those tests will eat the 'comments' uri path segment)~~

PR for #564