### PR TITLE
#582 added Env.self_webhook_base_url

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/Env.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/Env.java
@@ -69,4 +69,9 @@ public final class Env {
      * API Token for Stripe.
      */
     public static final String STRIPE_API_TOKEN = "self_stripe_token";
+
+    /**
+     * Webhook Base URL. E.g. http://self-xdsd.go.ro/pm
+     */
+    public static final String WEBHOOK_BASE_URL = "self_webhook_base_url";
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubWebhooks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubWebhooks.java
@@ -98,7 +98,7 @@ final class GithubWebhooks implements Webhooks {
                     Json.createObjectBuilder()
                         .add(
                             "url",
-                            "https://self-xdsd.com/github/"
+                            System.getenv(Env.WEBHOOK_BASE_URL) + "/github/"
                             + project.repoFullName()
                         )
                         .add("content_type", "json")

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabWebhooks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabWebhooks.java
@@ -95,7 +95,7 @@ final class GitlabWebhooks implements Webhooks {
             Json.createObjectBuilder()
                 .add("id", project.repoFullName()
                     .replace("/", "%2F"))
-                .add("url", "https://self-xdsd.com/gitlab/"
+                .add("url", System.getenv(Env.WEBHOOK_BASE_URL) + "/gitlab/"
                     + project.repoFullName())
                 .add("issues_events", true)
                 .add("token", project.webHookToken())

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubWebhooksTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubWebhooksTestCase.java
@@ -79,7 +79,7 @@ public final class GithubWebhooksTestCase {
                                     Json.createObjectBuilder()
                                         .add(
                                             "url",
-                                            "https://self-xdsd.com/github/"
+                                            "null/github/"
                                             + "amihaiemil/repo"
                                         )
                                         .add("content_type", "json")
@@ -146,7 +146,7 @@ public final class GithubWebhooksTestCase {
                                     Json.createObjectBuilder()
                                         .add(
                                             "url",
-                                            "https://self-xdsd.com/github/"
+                                            "null/github/"
                                                 + "amihaiemil/repo"
                                         )
                                         .add("content_type", "json")

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabWebhooksTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabWebhooksTestCase.java
@@ -70,7 +70,7 @@ public final class GitlabWebhooksTestCase {
                         req.getBody(),
                         Matchers.equalTo(Json.createObjectBuilder()
                             .add("id", "amihaiemil%2Frepo")
-                            .add("url", "https://self-xdsd.com/gitlab/"
+                            .add("url", "null/gitlab/"
                                 + "amihaiemil/repo")
                             .add("issues_events", true)
                             .add("token", "webhook_tok333n")


### PR DESCRIPTION
Fixes #582 

The base uri for the Webhook can now be specified via the ``self_webhook_base_url`` env variable.