### PR TITLE
#587 When registering task, check for Issue closed

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/IssueIsClosed.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/IssueIsClosed.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core.managers;
+
+import com.selfxdsd.api.Event;
+import com.selfxdsd.api.Issue;
+import com.selfxdsd.api.pm.PreconditionCheck;
+import com.selfxdsd.api.pm.Step;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Step where we check if the event's Issue is closed or not.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.26
+ */
+public final class IssueIsClosed extends PreconditionCheck {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(
+        IssueIsClosed.class
+    );
+
+    /**
+     * Ctor.
+     * @param onTrue Step to follow if the Issue is closed.
+     * @param onFalse Step to follow if the Issue is NOT closed.
+     */
+    public IssueIsClosed(
+        final Step onTrue,
+        final Step onFalse
+    ) {
+        super(onTrue, onFalse);
+    }
+
+    @Override
+    public void perform(final Event event) {
+        final Issue issue = event.issue();
+        LOG.debug("Checking if Issue #" + issue.issueId() + " is closed...");
+        if(issue.isClosed()) {
+            LOG.debug("Issue #" + issue.issueId() + " is closed.");
+            this.onTrue().perform(event);
+        } else {
+            LOG.debug("Issue #" + issue.issueId() + " is NOT closed.");
+            this.onFalse().perform(event);
+        }
+    }
+}

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/Register.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/Register.java
@@ -66,30 +66,42 @@ public final class Register implements Conversation {
         if(Event.Type.REGISTER.equals(event.type())) {
             final Language language = event.project().language();
             final String author = event.comment().author();
-            steps = new AuthorHasRoles(
-                new TaskIsRegistered(
-                    new SendReply(
-                        String.format(
-                            language.reply("taskAlreadyRegistered.comment"),
-                            author
-                        )
-                    ),
-                    new RegisterIssue(
-                        new SendReply(
-                            String.format(
-                                language.reply("taskRegistered.comment"),
-                                author
-                            )
-                        )
-                    )
-                ),
+            steps = new IssueIsClosed(
                 new SendReply(
                     String.format(
-                        language.reply("mustBeContributor.comment"),
+                        language.reply("issueClosed.comment"),
                         author
                     )
                 ),
-                Contract.Roles.ANY
+                new AuthorHasRoles(
+                    new TaskIsRegistered(
+                        new SendReply(
+                            String.format(
+                                language.reply(
+                                    "taskAlreadyRegistered.comment"
+                                ),
+                                author
+                            )
+                        ),
+                        new RegisterIssue(
+                            new SendReply(
+                                String.format(
+                                    language.reply(
+                                        "taskRegistered.comment"
+                                    ),
+                                    author
+                                )
+                            )
+                        )
+                    ),
+                    new SendReply(
+                        String.format(
+                            language.reply("mustBeContributor.comment"),
+                            author
+                        )
+                    ),
+                    Contract.Roles.ANY
+                )
             );
         } else {
             steps = this.notRegister.start(event);

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/IssueIsClosedTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/IssueIsClosedTestCase.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core.managers;
+
+import com.selfxdsd.api.Event;
+import com.selfxdsd.api.Issue;
+import com.selfxdsd.api.pm.Step;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for {@link IssueIsClosed}.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.26
+ */
+public final class IssueIsClosedTestCase {
+
+    /**
+     * IssueIsClosed can perform on a closed Issue.
+     */
+    @Test
+    public void performsOnClosedIssue() {
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.isClosed()).thenReturn(Boolean.TRUE);
+        final Event event = Mockito.mock(Event.class);
+        Mockito.when(event.issue()).thenReturn(issue);
+
+        final Step onTrue = Mockito.mock(Step.class);
+        final IssueIsClosed issueIsClosed = new IssueIsClosed(
+            onTrue,
+            onFalse -> {
+                throw new IllegalStateException(
+                    "OnFalse should not be called, since the Issue is closed."
+                );
+            }
+        );
+        issueIsClosed.perform(event);
+        Mockito.verify(onTrue, Mockito.times(1)).perform(event);
+    }
+
+    /**
+     * IssueIsClosed can perform on an open Issue.
+     */
+    @Test
+    public void performsOnOpenIssue() {
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.isClosed()).thenReturn(Boolean.FALSE);
+        final Event event = Mockito.mock(Event.class);
+        Mockito.when(event.issue()).thenReturn(issue);
+
+        final Step onFalse = Mockito.mock(Step.class);
+        final IssueIsClosed issueIsClosed = new IssueIsClosed(
+            onTrue -> {
+                throw new IllegalStateException(
+                    "OnTrue should not be called, since the Issue is open."
+                );
+            },
+            onFalse
+        );
+        issueIsClosed.perform(event);
+        Mockito.verify(onFalse, Mockito.times(1)).perform(event);
+    }
+}

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/RegisterTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/RegisterTestCase.java
@@ -68,7 +68,7 @@ public final class RegisterTestCase {
             register.start(event),
             Matchers.allOf(
                 Matchers.notNullValue(),
-                Matchers.instanceOf(AuthorHasRoles.class)
+                Matchers.instanceOf(IssueIsClosed.class)
             )
         );
     }

--- a/self-core-impl/src/test/resources/responses_en.properties
+++ b/self-core-impl/src/test/resources/responses_en.properties
@@ -41,3 +41,5 @@ taskDeadlineReminder.comment=@%s Don't forget to close this ticket before the de
                              of the allowed period.
 taskDeadlineMissed.comment=@%s Looks like you've missed the task deadline (%s). You are now resigned from this task.\n\n\
                            Please stop working on it, you will not be paid. I will assign it to someone else soon.
+issueClosed.comment=@%s this Issue is closed. If you want me to do anything with it, reopen it first.\n\n\
+                    However, reopening issues is discouraged, please consider opening new tickets instead.


### PR DESCRIPTION
Fixes #587 

When registering an issue as a task, we should first check if the Issue is closed or not.
Added IssueIsClosed precondition Step and unit tests for it.
