### PR TITLE
#603 UnassinTask removes the Issue assignee as well

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/UnassignTask.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/UnassignTask.java
@@ -22,10 +22,7 @@
  */
 package com.selfxdsd.core.managers;
 
-import com.selfxdsd.api.Event;
-import com.selfxdsd.api.Project;
-import com.selfxdsd.api.Resignations;
-import com.selfxdsd.api.Task;
+import com.selfxdsd.api.*;
 import com.selfxdsd.api.pm.Intermediary;
 import com.selfxdsd.api.pm.Step;
 import org.slf4j.Logger;
@@ -36,9 +33,6 @@ import org.slf4j.LoggerFactory;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.20
- * @todo #585:30min When unassigning the Task, we should also remove
- *  the Issue assignee (if any) and leave a comment to let them know
- *  about it.
  */
 public final class UnassignTask extends Intermediary {
 
@@ -77,6 +71,10 @@ public final class UnassignTask extends Intermediary {
             );
             task.resignations().register(task, Resignations.Reason.ASKED);
             final Task unassigned = task.unassign();
+            final Issue issue = event.issue();
+            if(issue.assignee() != null) {
+                issue.unassign(issue.assignee());
+            }
             if(unassigned.assignee() == null) {
                 LOG.debug("Resignation successful!");
             } else {

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/DeregisterTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/DeregisterTestCase.java
@@ -99,8 +99,9 @@ public final class DeregisterTestCase {
             Matchers.nullValue());
         Mockito.verify(issue.comments(), Mockito.times(1))
             .post("> Deregister please!\n\n"
-                + "@john-arch task successfully removed.");
-
+                + "@john-arch ok, I've removed this task from scope. "
+                + "I'm not managing it anymore."
+            );
     }
 
     /**

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/UnassignTaskTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/UnassignTaskTestCase.java
@@ -110,6 +110,7 @@ public final class UnassignTaskTestCase {
         final Event event = Mockito.mock(Event.class);
         final Issue issue = Mockito.mock(Issue.class);
         Mockito.when(issue.issueId()).thenReturn("1");
+        Mockito.when(issue.assignee()).thenReturn("mihai");
         Mockito.when(event.issue()).thenReturn(issue);
 
         final Tasks tasks = Mockito.mock(Tasks.class);
@@ -133,6 +134,8 @@ public final class UnassignTaskTestCase {
         Mockito.verify(task.resignations(), Mockito.times(1))
             .register(task, Resignations.Reason.ASKED);
         Mockito.verify(next, Mockito.times(1)).perform(event);
+        Mockito.verify(issue, Mockito.times(2)).assignee();
+        Mockito.verify(issue, Mockito.times(1)).unassign("mihai");
     }
 
 }

--- a/self-core-impl/src/test/resources/responses_en.properties
+++ b/self-core-impl/src/test/resources/responses_en.properties
@@ -27,7 +27,7 @@ pullRequestAssigned.comment=@%s please review this Pull Request. Deadline (when 
 resigned.comment=@%s ok, I'll find someone else to take care of it.
 cannotResign.comment=@%s this task is not assigned to you at the moment.\
                      Only the task's assignee can ask for resignation.
-deregister.comment=@%s task successfully removed.
+deregister.comment=@%s ok, I've removed this task from scope. I'm not managing it anymore.
 cannotDeregister.comment=@%s you don't have the appropriate role to remove this task.\n\n\
                          Only users with PO or ARCH roles are allowed.
 taskNotRegistered.comment=@%s this ticket is not registered as a task, therefore I'm not working on it\


### PR DESCRIPTION
PR for #603 

When unasigning a Task we should also remove the assignee from the Issue.
Better deregister comment.
Updated test.