### PR TITLE
#627 newIssue: check for the 'no-task' label

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Issue.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Issue.java
@@ -22,6 +22,8 @@
  */
 package com.selfxdsd.api;
 
+import com.selfxdsd.api.storage.Labels;
+
 import javax.json.JsonObject;
 
 /**
@@ -124,4 +126,9 @@ public interface Issue {
      */
     int estimation();
 
+    /**
+     * Labels of this Issue.
+     * @return Issues.
+     */
+    Labels labels();
 }

--- a/self-api/src/main/java/com/selfxdsd/api/Issues.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Issues.java
@@ -22,8 +22,6 @@
  */
 package com.selfxdsd.api;
 
-import com.selfxdsd.api.storage.Labels;
-
 import javax.json.JsonObject;
 
 /**
@@ -70,10 +68,4 @@ public interface Issues extends Iterable<Issue> {
      * @return Issues.
      */
     Issues search(final String text, final String... labels);
-
-    /**
-     * Labels of this Issue.
-     * @return Issues.
-     */
-    Labels labels();
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/FoundIssues.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/FoundIssues.java
@@ -24,7 +24,6 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Issue;
 import com.selfxdsd.api.Issues;
-import com.selfxdsd.api.storage.Labels;
 
 import javax.json.JsonObject;
 import java.util.ArrayList;
@@ -92,11 +91,6 @@ final class FoundIssues implements Issues {
         final String... labels
     ) {
         return this.original.search(text, labels);
-    }
-
-    @Override
-    public Labels labels() {
-        return this.original.labels();
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssue.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssue.java
@@ -25,6 +25,7 @@ package com.selfxdsd.core;
 import com.selfxdsd.api.Comments;
 import com.selfxdsd.api.Contract;
 import com.selfxdsd.api.Issue;
+import com.selfxdsd.api.storage.Labels;
 import com.selfxdsd.api.storage.Storage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -279,5 +280,13 @@ final class GithubIssue implements Issue {
             estimation = 60;
         }
         return estimation;
+    }
+
+    @Override
+    public Labels labels() {
+        return new GithubIssueLabels(
+            URI.create(this.issueUri.toString() + "/labels"),
+            this.resources
+        );
     }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssues.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssues.java
@@ -24,7 +24,6 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Issue;
 import com.selfxdsd.api.Issues;
-import com.selfxdsd.api.storage.Labels;
 import com.selfxdsd.api.storage.Storage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -222,14 +221,6 @@ final class GithubIssues implements Issues {
             );
         }
         return new FoundIssues(this, found);
-    }
-
-    @Override
-    public Labels labels() {
-        return new GithubIssueLabels(
-            URI.create(this.issuesUri.toString() + "/labels"),
-            this.resources
-        );
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/IssueHasLabel.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/IssueHasLabel.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core.managers;
 
 import com.selfxdsd.api.Event;
 import com.selfxdsd.api.Issue;
+import com.selfxdsd.api.Label;
 import com.selfxdsd.api.Project;
 import com.selfxdsd.api.pm.PreconditionCheck;
 import com.selfxdsd.api.pm.Step;
@@ -75,5 +76,29 @@ public final class IssueHasLabel extends PreconditionCheck {
             + " at " + project.provider() + " has the label ["
             + this.label + "]..."
         );
+        boolean hasLabel = false;
+        for(final Label label : issue.labels()) {
+            if(this.label.equalsIgnoreCase(label.name())) {
+                hasLabel = true;
+                break;
+            }
+        }
+        if(hasLabel) {
+            LOG.debug(
+                "Issue #" + issue.issueId()
+                + " from Project " + project.repoFullName()
+                + " at " + project.provider() + " does have the label ["
+                + this.label + "]!"
+            );
+            this.onTrue().perform(event);
+        } else {
+            LOG.debug(
+                "Issue #" + issue.issueId()
+                + " from Project " + project.repoFullName()
+                + " at " + project.provider() + " does NOT have the label ["
+                + this.label + "]!"
+            );
+            this.onFalse().perform(event);
+        }
     }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/IssueHasLabel.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/IssueHasLabel.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core.managers;
+
+import com.selfxdsd.api.Event;
+import com.selfxdsd.api.Issue;
+import com.selfxdsd.api.Project;
+import com.selfxdsd.api.pm.PreconditionCheck;
+import com.selfxdsd.api.pm.Step;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Step where we check if the Issue has the given label or not.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.30
+ */
+public final class IssueHasLabel extends PreconditionCheck {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(
+        IssueHasLabel.class
+    );
+
+    /**
+     * The label we're looking for.
+     */
+    private final String label;
+
+    /**
+     * Ctor.
+     * @param label Label we're looking for.
+     * @param onTrue Step to follow if the Issue has the label.
+     * @param onFalse Step to follow if the Issue does NOT have the label.
+     */
+    public IssueHasLabel(
+        final String label,
+        final Step onTrue,
+        final Step onFalse
+    ) {
+        super(onTrue, onFalse);
+        this.label = label;
+    }
+
+    @Override
+    public void perform(final Event event) {
+        final Project project = event.project();
+        final Issue issue = event.issue();
+        LOG.debug(
+            "Checking if Issue #" + issue.issueId()
+            + " from Project " + project.repoFullName()
+            + " at " + project.provider() + " has the label ["
+            + this.label + "]..."
+        );
+    }
+}

--- a/self-core-impl/src/test/java/com/selfxdsd/core/FoundIssuesTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/FoundIssuesTestCase.java
@@ -24,7 +24,6 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Issue;
 import com.selfxdsd.api.Issues;
-import com.selfxdsd.api.storage.Labels;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -192,17 +191,4 @@ public final class FoundIssuesTestCase {
         );
     }
 
-    /**
-     * FoundIssue.labels(...) should be delegated to the
-     * original Issues labels.
-     */
-    @Test
-    public void labelsDelegatesToOriginal(){
-        final Issues original = Mockito.mock(Issues.class);
-        final Labels labels = Mockito.mock(Labels.class);
-        Mockito.when(original.labels()).thenReturn(labels);
-        final Issues found = new FoundIssues(original, List.of());
-        MatcherAssert.assertThat(found.labels(),
-            Matchers.equalTo(original.labels()));
-    }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssuesTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssuesTestCase.java
@@ -26,7 +26,6 @@ import com.selfxdsd.api.Issue;
 import com.selfxdsd.api.Issues;
 import com.selfxdsd.api.Provider;
 import com.selfxdsd.api.User;
-import com.selfxdsd.api.storage.Labels;
 import com.selfxdsd.api.storage.Storage;
 import com.selfxdsd.core.mock.MockJsonResources;
 import org.hamcrest.MatcherAssert;
@@ -546,22 +545,5 @@ public final class GithubIssuesTestCase {
         MatcherAssert.assertThat(
             found, Matchers.emptyIterable()
         );
-    }
-
-    /**
-     * GithubIssues has labels.
-     */
-    @Test
-    public void hasLabels(){
-        final Issues issues = new GithubIssues(
-            Mockito.mock(JsonResources.class),
-            URI.create(
-                "https://api.github.com/repos/amihaiemil/docker-java-api/issues"
-            ),
-            mock(Storage.class)
-        );
-        final Labels labels = issues.labels();
-        MatcherAssert.assertThat(labels, Matchers
-            .instanceOf(GithubIssueLabels.class));
     }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/IssueHasLabelTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/IssueHasLabelTestCase.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core.managers;
+
+import com.selfxdsd.api.Event;
+import com.selfxdsd.api.Issue;
+import com.selfxdsd.api.Label;
+import com.selfxdsd.api.Project;
+import com.selfxdsd.api.pm.Step;
+import com.selfxdsd.api.storage.Labels;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Unit tests for {@link IssueHasLabel}.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.30
+ */
+public final class IssueHasLabelTestCase {
+
+    /**
+     * Issue has the label. OnTrue should be called.
+     */
+    @Test
+    public void issueHasTheLabel() {
+        final Label label = Mockito.mock(Label.class);
+        Mockito.when(label.name()).thenReturn("the-label");
+        final List<Label> list = Arrays.asList(label);
+        final Labels labels = Mockito.mock(Labels.class);
+        Mockito.when(labels.iterator()).thenReturn(list.iterator());
+
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.labels()).thenReturn(labels);
+
+        final Event event = Mockito.mock(Event.class);
+        Mockito.when(event.issue()).thenReturn(issue);
+        Mockito.when(event.project()).thenReturn(Mockito.mock(Project.class));
+
+        final Step onTrue = Mockito.mock(Step.class);
+        final Step step = new IssueHasLabel(
+            "the-label",
+            onTrue,
+            onFalse -> {
+                throw new IllegalStateException("Should not be called.");
+            }
+        );
+
+        step.perform(event);
+        Mockito.verify(onTrue, Mockito.times(1)).perform(event);
+    }
+
+    /**
+     * Issue does NOT have the label. OnFalse should be called.
+     */
+    @Test
+    public void issueDoesNotHaveTheLabel() {
+        final Label label = Mockito.mock(Label.class);
+        Mockito.when(label.name()).thenReturn("the-label");
+        final List<Label> list = Arrays.asList(label);
+        final Labels labels = Mockito.mock(Labels.class);
+        Mockito.when(labels.iterator()).thenReturn(list.iterator());
+
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.labels()).thenReturn(labels);
+
+        final Event event = Mockito.mock(Event.class);
+        Mockito.when(event.issue()).thenReturn(issue);
+        Mockito.when(event.project()).thenReturn(Mockito.mock(Project.class));
+
+        final Step onFalse = Mockito.mock(Step.class);
+        final Step step = new IssueHasLabel(
+            "other-label",
+            onTrue -> {
+                throw new IllegalStateException("Should not be called.");
+            },
+            onFalse
+        );
+
+        step.perform(event);
+        Mockito.verify(onFalse, Mockito.times(1)).perform(event);
+    }
+}

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
@@ -22,6 +22,7 @@
 package com.selfxdsd.core.managers;
 
 import com.selfxdsd.api.*;
+import com.selfxdsd.api.storage.Labels;
 import com.selfxdsd.api.storage.Storage;
 import com.selfxdsd.core.Github;
 import com.selfxdsd.core.mock.InMemory;
@@ -257,7 +258,11 @@ public final class StoredProjectManagerTestCase {
             BigDecimal.valueOf(50),
             Mockito.mock(Storage.class)
         );
+        final Labels labels = Mockito.mock(Labels.class);
+        Mockito.when(labels.iterator())
+            .thenReturn(new ArrayList<Label>().iterator());
         final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.labels()).thenReturn(labels);
         Mockito.when(issue.issueId()).thenReturn("1");
         Mockito.when(issue.author()).thenReturn("mihai");
         Mockito.when(issue.repoFullName()).thenReturn("mihai/test");


### PR DESCRIPTION
Fixes #627 

Implemented and tested ``IssueHasLabel`` Step.
Moved method ``Labels :: labels()`` from interface ``Issues`` to interface ``Issue``.
Refactored StoredProjectManager.newIssue(...) to a Step-based approach.
