### PR TITLE
#629 Github passed to GithubInvitation for Repo starring

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/Github.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/Github.java
@@ -122,7 +122,8 @@ public final class Github implements Provider {
             this.resources,
             URI.create(
                 this.uri.toString() + "/user/repository_invitations"
-            )
+            ),
+            this
         );
     }
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepoInvitations.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepoInvitations.java
@@ -52,16 +52,24 @@ final class GithubRepoInvitations implements Invitations {
     private final URI repoInvitationsUri;
 
     /**
+     * Parent Github.
+     */
+    private final Github github;
+
+    /**
      * Ctor.
      * @param resources Github's JSON resources.
      * @param repoInvitationsUri API uri.
+     * @param github Parent Github.
      */
     GithubRepoInvitations(
         final JsonResources resources,
-        final URI repoInvitationsUri
+        final URI repoInvitationsUri,
+        final Github github
     ) {
         this.resources = resources;
         this.repoInvitationsUri = repoInvitationsUri;
+        this.github = github;
     }
 
     @Override
@@ -71,7 +79,8 @@ final class GithubRepoInvitations implements Invitations {
                 jsonValue -> new GithubInvitation(
                     this.resources,
                     this.repoInvitationsUri,
-                    (JsonObject) jsonValue
+                    (JsonObject) jsonValue,
+                    this.github
                 )
             ).collect(Collectors.toList());
         return invitations.iterator();


### PR DESCRIPTION
Fixes #629 

Github is passed down to GithubInvitation for starring the Repo after accepting Invitation.
Added logging and removed old puzzle.
Left puzzle to actually star the repo after we have method Repo.star() in place.