### PR TITLE
#626 Handle New Issues with assignee

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/AssignTaskToIssueAssignee.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/AssignTaskToIssueAssignee.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core.managers;
+
+import com.selfxdsd.api.*;
+import com.selfxdsd.api.pm.Intermediary;
+import com.selfxdsd.api.pm.Step;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Step where we assign the corresponding Task to the Issue's assignee.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.30
+ */
+public final class AssignTaskToIssueAssignee extends Intermediary {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(
+        AssignTaskToIssueAssignee.class
+    );
+
+    /**
+     * Ctor.
+     * @param next The next step to perform.
+     */
+    public AssignTaskToIssueAssignee(final Step next) {
+        super(next);
+    }
+
+    @Override
+    public void perform(final Event event) {
+        final Issue issue = event.issue();
+        final String issueId = issue.issueId();
+        final Project project = event.project();
+        final Task task = project.tasks().getById(
+            issueId, project.repoFullName(), project.provider()
+        );
+        if(task == null) {
+            LOG.debug(
+                "Issue #" + issueId + " in project " + project.repoFullName()
+                + " at " + project.provider()
+                + " is not registered as a Task, can't assign anyone!"
+            );
+        } else {
+            final String assignee = issue.assignee();
+            final Task assigned = task.assign(
+                project.contributors()
+                    .getById(assignee, project.provider())
+            );
+            LOG.debug(
+                "Task #" + assigned.issueId()
+                + " assigned to Contributor @" + assignee
+                + " who was already assigned to the Issue."
+            );
+            final String comment = String.format(
+                project.language().reply("taskAssigned.comment"),
+                assignee,
+                assigned.deadline(),
+                assigned.estimation()
+            );
+            issue.comments().post(comment);
+        }
+        this.next().perform(event);
+    }
+}

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/Deregister.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/Deregister.java
@@ -81,7 +81,9 @@ public final class Deregister implements Conversation {
                         language.reply("cannotDeregister.comment"),
                         author
                     )
-                ), Contract.Roles.PO, Contract.Roles.ARCH
+                ),
+                event,
+                Contract.Roles.PO, Contract.Roles.ARCH
             );
         } else {
             steps = this.notDeregister.start(event);

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/IssueAssigneeHasRoles.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/IssueAssigneeHasRoles.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core.managers;
+
+import com.selfxdsd.api.Event;
+import com.selfxdsd.api.pm.Step;
+
+/**
+ * Check if the Issue's assignee has some roles.<br><br>
+ *
+ * The first constructor (which accepts no roles), is used to check
+ * that the Issue's assignee has the role required by the Issue itself.
+ *
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.30
+ */
+public final class IssueAssigneeHasRoles extends UserHasRoles {
+
+    /**
+     * Ctor.
+     *
+     * @param onTrue Step to follow if the author has on of the given roles.
+     * @param onFalse Step to follow if the author none of the given roles.
+     * @param event Event.
+     */
+    public IssueAssigneeHasRoles(
+        final Step onTrue,
+        final Step onFalse,
+        final Event event
+    ) {
+        this(onTrue, onFalse, event, event.issue().role());
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param onTrue Step to follow if the author has on of the given roles.
+     * @param onFalse Step to follow if the author none of the given roles.
+     * @param event Event.
+     * @param roles Roles we're interested in.
+     */
+    public IssueAssigneeHasRoles(
+        final Step onTrue,
+        final Step onFalse,
+        final Event event,
+        final String... roles
+    ) {
+        super(onTrue, onFalse, event.issue().assignee(), roles);
+    }
+}

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/IssueIsAssigned.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/IssueIsAssigned.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core.managers;
+
+import com.selfxdsd.api.Event;
+import com.selfxdsd.api.Issue;
+import com.selfxdsd.api.Project;
+import com.selfxdsd.api.pm.PreconditionCheck;
+import com.selfxdsd.api.pm.Step;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Step where we check if the Issue is assigned to someone or not.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.30
+ */
+public final class IssueIsAssigned extends PreconditionCheck {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(
+        IssueIsAssigned.class
+    );
+
+    /**
+     * Ctor.
+     * @param onTrue Step to perform if Issue is assigned.
+     * @param onFalse Step to perform if the Issue is NOT assigned.
+     */
+    public IssueIsAssigned(final Step onTrue, final Step onFalse) {
+        super(onTrue, onFalse);
+    }
+
+    @Override
+    public void perform(final Event event) {
+        final Project project = event.project();
+        final Issue issue = event.issue();
+        LOG.debug(
+            "Checking if Issue #" + issue.issueId() + " from Project "
+            + project.repoFullName() + " at " + project.provider()
+            + " is assigned to anyone..."
+        );
+        final String assignee = issue.assignee();
+        if(assignee != null && !assignee.trim().isEmpty()) {
+            LOG.debug(
+                "Issue #" + issue.issueId()
+                + " is assigned to " + assignee + ". "
+            );
+            this.onTrue().perform(event);
+        } else {
+            LOG.debug("Issue #" + issue.issueId() + " is NOT assigned.");
+            this.onFalse().perform(event);
+        }
+    }
+}

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/Register.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/Register.java
@@ -100,6 +100,7 @@ public final class Register implements Conversation {
                             author
                         )
                     ),
+                    event,
                     Contract.Roles.ANY
                 )
             );

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/UnassignIssue.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/UnassignIssue.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core.managers;
+
+import com.selfxdsd.api.Event;
+import com.selfxdsd.api.Issue;
+import com.selfxdsd.api.Project;
+import com.selfxdsd.api.pm.Intermediary;
+import com.selfxdsd.api.pm.Step;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Step where we unassign an Issue. We may want to do this, for instance,
+ * when the Issue assignee is not a Contributor in the project.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.30
+ */
+public final class UnassignIssue extends Intermediary {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(
+        UnassignIssue.class
+    );
+
+    /**
+     * Ctor.
+     * @param next The next step to perform.
+     */
+    public UnassignIssue(final Step next) {
+        super(next);
+    }
+
+    @Override
+    public void perform(final Event event) {
+        final Issue issue = event.issue();
+        final Project project = event.project();
+        final String assignee = issue.assignee();
+        if(assignee != null) {
+            boolean success = issue.unassign(assignee);
+            if(success) {
+                LOG.debug(
+                    "User @" + assignee + " unassigned from "
+                    + "issue #" + issue.issueId() + " (project "
+                    + project.repoFullName() + " at " + project.provider()
+                    + ")."
+                );
+            } else {
+                LOG.debug(
+                    "Unexpected response when trying to unassign user @"
+                    + assignee + " from issue #" + issue.issueId() + "(project"
+                    + " " + project.repoFullName() + " at "
+                    + project.provider() + ")."
+                );
+            }
+        }
+        this.next().perform(event);
+    }
+}

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/UserHasRoles.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/UserHasRoles.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core.managers;
+
+import com.selfxdsd.api.*;
+import com.selfxdsd.api.pm.PreconditionCheck;
+import com.selfxdsd.api.pm.Step;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Intermediary step where we check if a user has certain Contributor roles.
+ * <br><br>
+ *
+ * This class is abstract and it should be extended by more specialized
+ * classes, which will set the user we're interested in (issue comment
+ * author, issue assignee etc) and the roles we're looking for.
+ *
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.30
+ */
+public abstract class UserHasRoles extends PreconditionCheck {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(
+        UserHasRoles.class
+    );
+
+    /**
+     * User we're interested in (login username).
+     */
+    private final String user;
+
+    /**
+     * Roles.
+     */
+    private final List<String> roles;
+
+    /**
+     * Ctor.
+     * @param onTrue Step to follow if the author has on of the given roles.
+     * @param onFalse Step to follow if the author none of the given roles.
+     * @param user User we're interested in.
+     * @param roles Roles.
+     */
+    public UserHasRoles(
+        final Step onTrue,
+        final Step onFalse,
+        final String user,
+        final String... roles
+    ) {
+        super(onTrue, onFalse);
+        this.user = user;
+        this.roles = Arrays.asList(roles);
+    }
+
+    @Override
+    public final void perform(final Event event) {
+        final Project project = event.project();
+        final Contributor contributor = project
+            .contributors()
+            .getById(this.user, project.provider());
+        if (contributor == null) {
+            LOG.debug("User " + this.user + " is not a contributor "
+                + " of this project.");
+            this.onFalse().perform(event);
+        } else {
+            boolean hasRole = false;
+            if(this.roles.contains(Contract.Roles.ANY)) {
+                hasRole = true;
+            } else {
+                final Contracts contracts = project.contracts()
+                    .ofContributor(contributor);
+                for (final Contract contract : contracts) {
+                    if (this.roles.contains(contract.role())) {
+                        hasRole = true;
+                        break;
+                    }
+                }
+            }
+            if (hasRole) {
+                LOG.debug("User " + this.user + " has the right role.");
+                this.onTrue().perform(event);
+            } else {
+                LOG.debug(
+                    "User " + this.user
+                    + " does NOT have the right role."
+                );
+                this.onFalse().perform(event);
+            }
+        }
+    }
+
+}

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/AssignTaskToIssueAssigneeTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/AssignTaskToIssueAssigneeTestCase.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core.managers;
+
+import com.selfxdsd.api.*;
+import com.selfxdsd.api.pm.Step;
+import com.selfxdsd.core.projects.English;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for {@link AssignTaskToIssueAssignee}.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.30
+ * @checkstyle ExecutableStatementCount (300 lines)
+ */
+public final class AssignTaskToIssueAssigneeTestCase {
+
+    /**
+     * It assigns the corresponding Task to the Issue's assignee.
+     */
+    @Test
+    public void assignsTheTask() {
+        final Task assigned = Mockito.mock(Task.class);
+
+        final Task task = Mockito.mock(Task.class);
+        final Contributor contributor = Mockito.mock(Contributor.class);
+        Mockito.when(task.assign(contributor)).thenReturn(assigned);
+
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.issueId()).thenReturn("123");
+        Mockito.when(issue.assignee()).thenReturn("mihai");
+        Mockito.when(issue.comments()).thenReturn(
+            Mockito.mock(Comments.class)
+        );
+
+        final Tasks ofProject = Mockito.mock(Tasks.class);
+        Mockito.when(
+            ofProject.getById(
+                "123", "mihai/test", Provider.Names.GITHUB
+            )
+        ).thenReturn(task);
+        final Contributors contributors = Mockito.mock(Contributors.class);
+        Mockito.when(
+            contributors.getById("mihai", Provider.Names.GITHUB)
+        ).thenReturn(contributor);
+
+        final Project project = Mockito.mock(Project.class);
+        Mockito.when(project.repoFullName()).thenReturn("mihai/test");
+        Mockito.when(project.provider()).thenReturn(Provider.Names.GITHUB);
+        Mockito.when(project.tasks()).thenReturn(ofProject);
+        Mockito.when(project.contributors()).thenReturn(contributors);
+        Mockito.when(project.language()).thenReturn(new English());
+
+        final Event event = Mockito.mock(Event.class);
+        Mockito.when(event.issue()).thenReturn(issue);
+        Mockito.when(event.project()).thenReturn(project);
+
+        final Step next = Mockito.mock(Step.class);
+
+        final Step assignTask = new AssignTaskToIssueAssignee(next);
+        assignTask.perform(event);
+
+        Mockito.verify(task, Mockito.times(1)).assign(contributor);
+        Mockito.verify(next, Mockito.times(1)).perform(event);
+    }
+
+    /**
+     * It should do nothing if the Issue does not have a corresponding Task.
+     */
+    @Test
+    public void skipsMissingTask() {
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.issueId()).thenReturn("123");
+        Mockito.when(issue.assignee()).thenReturn("mihai");
+
+        final Tasks ofProject = Mockito.mock(Tasks.class);
+        Mockito.when(
+            ofProject.getById(
+                "123", "mihai/test", Provider.Names.GITHUB
+            )
+        ).thenReturn(null);
+
+        final Project project = Mockito.mock(Project.class);
+        Mockito.when(project.repoFullName()).thenReturn("mihai/test");
+        Mockito.when(project.provider()).thenReturn(Provider.Names.GITHUB);
+        Mockito.when(project.tasks()).thenReturn(ofProject);
+
+        final Event event = Mockito.mock(Event.class);
+        Mockito.when(event.issue()).thenReturn(issue);
+        Mockito.when(event.project()).thenReturn(project);
+
+        final Step next = Mockito.mock(Step.class);
+        final Step assignTask = new AssignTaskToIssueAssignee(next);
+
+        assignTask.perform(event);
+
+        Mockito.verify(next, Mockito.times(1)).perform(event);
+    }
+}

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/AuthorHasRolesTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/AuthorHasRolesTestCase.java
@@ -73,6 +73,7 @@ public final class AuthorHasRolesTestCase {
                     "Should not be called!"
                 );
             },
+            event,
             Contract.Roles.ARCH, Contract.Roles.PO
         );
         step.perform(event);
@@ -112,6 +113,7 @@ public final class AuthorHasRolesTestCase {
                 );
             },
             onFalse,
+            event,
             Contract.Roles.DEV
         );
         step.perform(event);
@@ -151,6 +153,7 @@ public final class AuthorHasRolesTestCase {
                     "Should not be called!"
                 );
             },
+            event,
             Contract.Roles.ANY
         );
         step.perform(event);

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/IssueIsAssignedTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/IssueIsAssignedTestCase.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core.managers;
+
+import com.selfxdsd.api.Event;
+import com.selfxdsd.api.Issue;
+import com.selfxdsd.api.Project;
+import com.selfxdsd.api.pm.Step;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for {@link IssueIsAssigned}.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.30
+ */
+public final class IssueIsAssignedTestCase {
+
+    /**
+     * The issue is assigned, so onTrue should be called as next step.
+     */
+    @Test
+    public void issueIsAssigned() {
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.assignee()).thenReturn("mihai");
+
+        final Event event = Mockito.mock(Event.class);
+        Mockito.when(event.project()).thenReturn(Mockito.mock(Project.class));
+        Mockito.when(event.issue()).thenReturn(issue);
+
+        final Step onTrue = Mockito.mock(Step.class);
+        final Step step = new IssueIsAssigned(
+            onTrue,
+            onFalse -> {
+                throw new IllegalStateException("Should not be called");
+            }
+        );
+
+        step.perform(event);
+        Mockito.verify(onTrue, Mockito.times(1)).perform(event);
+    }
+
+    /**
+     * The issue is NOT assigned, so onFalse should be called as next step.
+     */
+    @Test
+    public void issueIsNotAssigned() {
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.assignee()).thenReturn(null);
+
+        final Event event = Mockito.mock(Event.class);
+        Mockito.when(event.project()).thenReturn(Mockito.mock(Project.class));
+        Mockito.when(event.issue()).thenReturn(issue);
+
+        final Step onFalse = Mockito.mock(Step.class);
+        final Step step = new IssueIsAssigned(
+            onTrue -> {
+                throw new IllegalStateException("Should not be called");
+            },
+            onFalse
+        );
+
+        step.perform(event);
+        Mockito.verify(onFalse, Mockito.times(1)).perform(event);
+    }
+}

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/UnassignIssueTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/UnassignIssueTestCase.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core.managers;
+
+import com.selfxdsd.api.Event;
+import com.selfxdsd.api.Issue;
+import com.selfxdsd.api.Project;
+import com.selfxdsd.api.pm.Step;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for {@link UnassignIssue}.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.30
+ */
+public final class UnassignIssueTestCase {
+
+    /**
+     * It unassigns the Issue, if the Issue has an assignee.
+     */
+    @Test
+    public void unassignsIssue() {
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.assignee()).thenReturn("mihai");
+        Mockito.when(issue.unassign("mihai")).thenReturn(true);
+        final Project project = Mockito.mock(Project.class);
+
+        final Event event = Mockito.mock(Event.class);
+        Mockito.when(event.issue()).thenReturn(issue);
+        Mockito.when(event.project()).thenReturn(project);
+
+        final Step next = Mockito.mock(Step.class);
+
+        final Step unassign = new UnassignIssue(next);
+        unassign.perform(event);
+
+        Mockito.verify(issue, Mockito.times(1)).unassign("mihai");
+        Mockito.verify(next, Mockito.times(1)).perform(event);
+    }
+
+    /**
+     * It doesn't do anything if the Issue does not have an assignee.
+     */
+    @Test
+    public void skipsUnassignedIssue() {
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.assignee()).thenReturn(null);
+        final Project project = Mockito.mock(Project.class);
+
+        final Event event = Mockito.mock(Event.class);
+        Mockito.when(event.issue()).thenReturn(issue);
+        Mockito.when(event.project()).thenReturn(project);
+
+        final Step next = Mockito.mock(Step.class);
+
+        final Step unassign = new UnassignIssue(next);
+        unassign.perform(event);
+
+        Mockito.verify(issue, Mockito.times(0)).unassign(Mockito.anyString());
+        Mockito.verify(next, Mockito.times(1)).perform(event);
+    }
+}

--- a/self-core-impl/src/test/resources/responses_en.properties
+++ b/self-core-impl/src/test/resources/responses_en.properties
@@ -2,6 +2,9 @@ hello.comment=Hi @%s! I'm the Project Manager of this project. I take care of Is
               Want me to work for your project too? Go [here](https://self-xdsd.com). \n\n\
               I work primarily at Github, but I'll also start working at GitLab and BitBucket soon.
 newIssue.comment=@%s thank you for reporting this. I'll assign someone to take care of it soon.
+newIssueUnassigned.comment=@%s thank you for reporting this. Unfortunately, @%s is not a contributor \
+                           with the required role (%s), that's why I unassigned them. \n\n\
+                           I will assign a contributor to take care of it soon.
 newPullRequest.comment=@%s thank you for your Pull Request. I'll assign someone to review it soon.
 reopened.comment=@%s thanks for reopening this, I'll find someone to take a look at it. \n\
                  However, please keep in mind that reopening tickets is a bad practice. Next time, please \
@@ -52,3 +55,5 @@ taskDeadlineMissed.comment=@%s Looks like you've missed the task deadline (%s). 
                            Please stop working on it, you will not be paid. I will assign it to someone else soon.
 issueClosed.comment=@%s this Issue is closed. If you want me to do anything with it, reopen it first.\n\n\
                     However, reopening issues is discouraged, please consider opening new tickets instead.
+manualAssignment.comment=@%s please keep in mind that manual assignment of tickets is a bad practice \
+                         and it is discouraged. Next time, please let me elect the assignee.


### PR DESCRIPTION
Fixes #626 

* Added and tested new steps: 
    * IssueAssigneeHasRoles
    * IssueIsAssigned
    *  UnassignIssue
    *  AssignTaskToIssueAssignee

* Modified the Step composition in StoredProjectManager.newIssue().
     - if the new issue has an assignee who is a contributor with required role -> assign the task to them
     - if the new issue has an assignee who is NOT a contributor with required role -> unassign issue

* Added new comments properties.