### PR TITLE
#646 Github Repo Commits & Commit Comments Implemented

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Commit.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Commit.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2020, Self XDSD Contributors
  * All rights reserved.
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"),
  * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
  * modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software.
- *
+ * <p>
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -22,75 +22,17 @@
  */
 package com.selfxdsd.api;
 
-import javax.json.JsonObject;
-
 /**
- * A Repository belonging to a com.selfxdsd.api.User on Github, Gitlab,
- * Bitbucket etc.
+ * Git commit.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 0.0.1
+ * @since 0.0.31
  */
-public interface Repo {
-    /**
-     * Owner of this repository.
-     * @return User.
-     */
-    User owner();
+public interface Commit {
 
     /**
-     * The Json representation of this Repo as returned by the API
-     * of the User's provider (Github, BitBucket etc).
-     * @return JsonObject.
+     * Comments on this commit.
+     * @return Comments.
      */
-    JsonObject json();
-
-    /**
-     * Activate this repository, tell Self to start
-     * managing it.
-     * @return Project.
-     */
-    Project activate();
-
-    /**
-     * This Repo's full name (e.g. amihaiemil/docker-java-api).
-     * @return String.
-     */
-    String fullName();
-
-    /**
-     * Provider name of this repository.
-     * @return Provider.
-     */
-    String provider();
-
-    /**
-     * The repo's Issues.
-     * @return Issues.
-     */
-    Issues issues();
-
-    /**
-     * The repo's collaborators.
-     * @return Collaborators.
-     */
-    Collaborators collaborators();
-
-    /**
-     * The repo's webhooks.
-     * @return Webhooks.
-     */
-    Webhooks webhooks();
-
-    /**
-     * Stars of this repo.
-     * @return Stars
-     */
-    Stars stars();
-
-    /**
-     * Commits of this repo.
-     * @return Commits.
-     */
-    Commits commits();
+    Comments comments();
 }

--- a/self-api/src/main/java/com/selfxdsd/api/Commit.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Commit.java
@@ -22,6 +22,8 @@
  */
 package com.selfxdsd.api;
 
+import javax.json.JsonObject;
+
 /**
  * Git commit.
  * @author Mihai Andronache (amihaiemil@gmail.com)
@@ -35,4 +37,16 @@ public interface Commit {
      * @return Comments.
      */
     Comments comments();
+
+    /**
+     * The author's username.
+     * @return String.
+     */
+    String author();
+
+    /**
+     * The Commit in JSON format as returned by the provider's API.
+     * @return JsonObject.
+     */
+    JsonObject json();
 }

--- a/self-api/src/main/java/com/selfxdsd/api/Commits.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Commits.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2020, Self XDSD Contributors
  * All rights reserved.
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"),
  * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
  * modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software.
- *
+ * <p>
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -22,75 +22,19 @@
  */
 package com.selfxdsd.api;
 
-import javax.json.JsonObject;
-
 /**
- * A Repository belonging to a com.selfxdsd.api.User on Github, Gitlab,
- * Bitbucket etc.
+ * Commits in a Repo.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 0.0.1
+ * @since 0.0.31
  */
-public interface Repo {
-    /**
-     * Owner of this repository.
-     * @return User.
-     */
-    User owner();
+public interface Commits extends Iterable<Commit> {
 
     /**
-     * The Json representation of this Repo as returned by the API
-     * of the User's provider (Github, BitBucket etc).
-     * @return JsonObject.
+     * Get a Commit by its ref.
+     * @param ref Ref ID.
+     * @return Commit or null if it's not found.
      */
-    JsonObject json();
+    Commit getCommit(final String ref);
 
-    /**
-     * Activate this repository, tell Self to start
-     * managing it.
-     * @return Project.
-     */
-    Project activate();
-
-    /**
-     * This Repo's full name (e.g. amihaiemil/docker-java-api).
-     * @return String.
-     */
-    String fullName();
-
-    /**
-     * Provider name of this repository.
-     * @return Provider.
-     */
-    String provider();
-
-    /**
-     * The repo's Issues.
-     * @return Issues.
-     */
-    Issues issues();
-
-    /**
-     * The repo's collaborators.
-     * @return Collaborators.
-     */
-    Collaborators collaborators();
-
-    /**
-     * The repo's webhooks.
-     * @return Webhooks.
-     */
-    Webhooks webhooks();
-
-    /**
-     * Stars of this repo.
-     * @return Stars
-     */
-    Stars stars();
-
-    /**
-     * Commits of this repo.
-     * @return Commits.
-     */
-    Commits commits();
 }

--- a/self-api/src/main/java/com/selfxdsd/api/Commits.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Commits.java
@@ -22,6 +22,8 @@
  */
 package com.selfxdsd.api;
 
+import javax.json.JsonObject;
+
 /**
  * Commits in a Repo.
  * @author Mihai Andronache (amihaiemil@gmail.com)
@@ -36,5 +38,14 @@ public interface Commits extends Iterable<Commit> {
      * @return Commit or null if it's not found.
      */
     Commit getCommit(final String ref);
+
+    /**
+     * Get a Commit from an existing JsonObject which
+     * Self may receive as part of an event sent
+     * by the Provider.
+     * @param commit The commit's JSON representation.
+     * @return Issue.
+     */
+    Commit received(final JsonObject commit);
 
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubCommit.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubCommit.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Comments;
+import com.selfxdsd.api.Commit;
+import com.selfxdsd.api.storage.Storage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.json.JsonObject;
+import java.net.URI;
+
+/**
+ * A Commit in Github.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.31
+ */
+final class GithubCommit implements Commit {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(
+        GithubCommit.class
+    );
+
+    /**
+     * Commit base uri.
+     */
+    private final URI commitUri;
+
+    /**
+     * Commit JSON as returned by Github's API.
+     */
+    private final JsonObject json;
+
+    /**
+     * Self storage, in case we want to store something.
+     */
+    private final Storage storage;
+
+    /**
+     * Github's JSON Resources.
+     */
+    private final JsonResources resources;
+
+    /**
+     * Ctor.
+     * @param commitUri Commit base URI.
+     * @param json Json Commit as returned by Github's API.
+     * @param storage Storage.
+     * @param resources Github's JSON Resources.
+     */
+    GithubCommit(
+        final URI commitUri,
+        final JsonObject json,
+        final Storage storage,
+        final JsonResources resources
+    ) {
+        this.commitUri = commitUri;
+        this.json = json;
+        this.storage = storage;
+        this.resources = resources;
+    }
+
+    @Override
+    public Comments comments() {
+        return null;
+    }
+
+    @Override
+    public String author() {
+        return this.json.getJsonObject("author").getString("login");
+    }
+
+    @Override
+    public JsonObject json() {
+        return this.json;
+    }
+}

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubCommits.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubCommits.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Commit;
+import com.selfxdsd.api.Commits;
+import com.selfxdsd.api.storage.Storage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.Iterator;
+
+/**
+ * Commits in a github Repo.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.31
+ */
+final class GithubCommits implements Commits {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(
+        GithubCommits.class
+    );
+
+    /**
+     * Github repo Commits base uri.
+     */
+    private final URI commitsUri;
+
+    /**
+     * Github's JSON Resources.
+     */
+    private final JsonResources resources;
+
+    /**
+     * Self storage, in case we want to store something.
+     */
+    private final Storage storage;
+
+    /**
+     * Ctor.
+     *
+     * @param resources Github's JSON Resources.
+     * @param commitsUri Commits base URI.
+     * @param storage Storage.
+     */
+    GithubCommits(
+        final JsonResources resources,
+        final URI commitsUri,
+        final Storage storage
+    ) {
+        this.resources = resources;
+        this.commitsUri = commitsUri;
+        this.storage = storage;
+    }
+
+    @Override
+    public Commit getCommit(final String ref) {
+        return null;
+    }
+
+    @Override
+    public Iterator<Commit> iterator() {
+        throw new UnsupportedOperationException(
+            "You cannot iterate over all the Commits in a Repo."
+        );
+    }
+}

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubCommits.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubCommits.java
@@ -126,6 +126,18 @@ final class GithubCommits implements Commits {
     }
 
     @Override
+    public Commit received(final JsonObject commit) {
+        return new GithubCommit(
+            URI.create(
+                this.commitsUri.toString() + "/" + commit.getString("sha")
+            ),
+            commit,
+            this.storage,
+            this.resources
+        );
+    }
+
+    @Override
     public Iterator<Commit> iterator() {
         throw new UnsupportedOperationException(
             "You cannot iterate over all the Commits in a Repo."

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepo.java
@@ -130,4 +130,9 @@ final class GithubRepo extends BaseRepo {
             this.storage()
         );
     }
+
+    @Override
+    public Commits commits() {
+        return null;
+    }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepo.java
@@ -133,6 +133,10 @@ final class GithubRepo extends BaseRepo {
 
     @Override
     public Commits commits() {
-        return null;
+        return new GithubCommits(
+            this.resources(),
+            URI.create(this.repoUri().toString() + "/commits"),
+            this.storage()
+        );
     }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepo.java
@@ -136,4 +136,11 @@ final class GitlabRepo extends BaseRepo {
             "Not yet implemented."
         );
     }
+
+    @Override
+    public Commits commits() {
+        throw new UnsupportedOperationException(
+            "Not yet implemented."
+        );
+    }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubCommitCommentsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubCommitCommentsTestCase.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Comment;
+import com.selfxdsd.api.Comments;
+import com.selfxdsd.core.mock.MockJsonResources;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.json.Json;
+import java.net.HttpURLConnection;
+import java.net.URI;
+
+/**
+ * Unit tests for {@link GithubCommitComments}.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.31
+ */
+public final class GithubCommitCommentsTestCase {
+
+    /**
+     * GithubCommitComments can receive a comment in JSON format.
+     */
+    @Test
+    public void receivesCommentFromJson(){
+        final Comments comments = new GithubCommitComments(
+            URI.create(
+                "localhost/repos/octocat/Hello-World/commits/ref1/comments"
+            ),
+            Mockito.mock(JsonResources.class)
+        );
+        final Comment received = comments.received(
+            Json.createObjectBuilder()
+                .add("body", "some comment here")
+                .build()
+        );
+        MatcherAssert.assertThat(
+            received,
+            Matchers.allOf(
+                Matchers.notNullValue(),
+                Matchers.instanceOf(GithubComment.class)
+            )
+        );
+        MatcherAssert.assertThat(
+            received.body(),
+            Matchers.equalTo("some comment here")
+        );
+    }
+
+    /**
+     * GithubCommitComments can post a comment.
+     */
+    @Test
+    public void postsCommentOk() {
+        final Comments comments = new GithubCommitComments(
+            URI.create("http://localhost/repos/mihai/test/commits/ref1"),
+            new MockJsonResources(
+                new AccessToken.Github("github123"),
+                req -> {
+                    MatcherAssert.assertThat(
+                        req.getAccessToken().value(),
+                        Matchers.equalTo("token github123")
+                    );
+                    MatcherAssert.assertThat(
+                        req.getMethod(),
+                        Matchers.equalTo("POST")
+                    );
+                    MatcherAssert.assertThat(
+                        req.getBody(),
+                        Matchers.equalTo(
+                            Json.createObjectBuilder()
+                                .add("body", "test comment")
+                                .build()
+                        )
+                    );
+                    MatcherAssert.assertThat(
+                        req.getUri().toString(),
+                        Matchers.equalTo(
+                            "http://localhost/repos/mihai/test/commits/ref1"
+                            + "/comments"
+                        )
+                    );
+                    return new MockJsonResources.MockResource(
+                        HttpURLConnection.HTTP_CREATED,
+                        Json.createObjectBuilder()
+                            .add("body", "test comment")
+                            .build()
+                    );
+                }
+            )
+        );
+        final Comment posted = comments.post("test comment");
+        MatcherAssert.assertThat(
+            posted.body(),
+            Matchers.equalTo("test comment")
+        );
+    }
+
+    /**
+     * GithubCommitComments complains if the comment cannot be posted.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void postsCommentNotFound() {
+        final Comments comments = new GithubCommitComments(
+            URI.create("http://localhost/repos/mihai/test/commits/ref1"),
+            new MockJsonResources(
+                new AccessToken.Github("github123"),
+                req -> {
+                    MatcherAssert.assertThat(
+                        req.getAccessToken().value(),
+                        Matchers.equalTo("token github123")
+                    );
+                    MatcherAssert.assertThat(
+                        req.getMethod(),
+                        Matchers.equalTo("POST")
+                    );
+                    MatcherAssert.assertThat(
+                        req.getBody(),
+                        Matchers.equalTo(
+                            Json.createObjectBuilder()
+                                .add("body", "test comment")
+                                .build()
+                        )
+                    );
+                    MatcherAssert.assertThat(
+                        req.getUri().toString(),
+                        Matchers.equalTo(
+                            "http://localhost/repos/mihai/test/commits/ref1"
+                                + "/comments"
+                        )
+                    );
+                    return new MockJsonResources.MockResource(
+                        HttpURLConnection.HTTP_NOT_FOUND,
+                        Json.createObjectBuilder().build()
+                    );
+                }
+            )
+        );
+        comments.post("test comment");
+    }
+}

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubCommitCommentsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubCommitCommentsTestCase.java
@@ -162,4 +162,16 @@ public final class GithubCommitCommentsTestCase {
         );
         comments.post("test comment");
     }
+
+    /**
+     * We cannot iterate over all of them for now.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void cannotIterate() {
+        final Comments comments = new GithubCommitComments(
+            URI.create("local/repos/mihai/test/commits/ref1"),
+            Mockito.mock(JsonResources.class)
+        );
+        comments.iterator();
+    }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubCommitTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubCommitTestCase.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Commit;
+import com.selfxdsd.api.storage.Storage;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import java.net.URI;
+
+/**
+ * Unit tests for {@link GithubCommit}.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.31
+ */
+public final class GithubCommitTestCase {
+
+    /**
+     * GithubCommit can return its json representation.
+     */
+    @Test
+    public void returnsJson() {
+        final JsonObject json = Json.createObjectBuilder().build();
+        final Commit commit = new GithubCommit(
+            URI.create("localhost:8080/repos/mihai/test/commits/123ref"),
+            json,
+            Mockito.mock(Storage.class),
+            Mockito.mock(JsonResources.class)
+        );
+        MatcherAssert.assertThat(
+            commit.json(),
+            Matchers.is(json)
+        );
+    }
+
+    /**
+     * GithubCommit can return its author.
+     */
+    @Test
+    public void returnsAuthor() {
+        final JsonObject json = Json.createObjectBuilder()
+            .add("sha", "123ref")
+            .add(
+                "author",
+                Json.createObjectBuilder().add("login", "mihai")
+            ).build();
+        final Commit commit = new GithubCommit(
+            URI.create("localhost:8080/repos/mihai/test/commits/123ref"),
+            json,
+            Mockito.mock(Storage.class),
+            Mockito.mock(JsonResources.class)
+        );
+        MatcherAssert.assertThat(
+            commit.author(),
+            Matchers.equalTo("mihai")
+        );
+    }
+
+}

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubCommitTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubCommitTestCase.java
@@ -82,4 +82,20 @@ public final class GithubCommitTestCase {
         );
     }
 
+    /**
+     * Returns Commit's comments.
+     */
+    @Test
+    public void returnsComments(){
+        final Commit commit = new GithubCommit(
+            URI.create("http://localhost/repos/mihai/test/commits/ref1"),
+            Json.createObjectBuilder().build(),
+            Mockito.mock(Storage.class),
+            Mockito.mock(JsonResources.class)
+        );
+        MatcherAssert.assertThat(
+            commit.comments(),
+            Matchers.instanceOf(GithubCommitComments.class)
+        );
+    }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubCommitsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubCommitsTestCase.java
@@ -174,4 +174,33 @@ public final class GithubCommitsTestCase {
         );
         commits.getCommit("123");
     }
+
+    /**
+     * GithubCommits can receive a Commit in JSON format.
+     */
+    @Test
+    public void receivesCommit() {
+        final Commits commits = new GithubCommits(
+            Mockito.mock(JsonResources.class),
+            URI.create("local/repos/mihai/test/commits/ref1"),
+            Mockito.mock(Storage.class)
+        );
+        final Commit received = commits.received(
+            Json.createObjectBuilder()
+                .add("sha", "12fe4d")
+                .add(
+                    "author",
+                    Json.createObjectBuilder()
+                        .add("login", "mihai")
+                ).build()
+        );
+        MatcherAssert.assertThat(
+            received,
+            Matchers.instanceOf(GithubCommit.class)
+        );
+        MatcherAssert.assertThat(
+            received.author(),
+            Matchers.equalTo("mihai")
+        );
+    }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubCommitsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubCommitsTestCase.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Commit;
+import com.selfxdsd.api.Commits;
+import com.selfxdsd.api.storage.Storage;
+import com.selfxdsd.core.mock.MockJsonResources;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.json.Json;
+import java.net.HttpURLConnection;
+import java.net.URI;
+
+/**
+ * Unit tests for {@link GithubCommits}.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.31
+ */
+public final class GithubCommitsTestCase {
+
+    /**
+     * We cannot iterate over all of them for now.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void cannotIterate() {
+        final Commits commits = new GithubCommits(
+            Mockito.mock(JsonResources.class),
+            URI.create("local/repos/mihai/test/commits/ref1"),
+            Mockito.mock(Storage.class)
+        );
+        commits.iterator();
+    }
+
+    /**
+     * GithubCommit can return a found commit (status 200 OK).
+     */
+    @Test
+    public void getFoundCommit() {
+        final Commits commits = new GithubCommits(
+            new MockJsonResources(
+                new AccessToken.Github("github123"),
+                req -> {
+                    MatcherAssert.assertThat(
+                        req.getAccessToken().value(),
+                        Matchers.equalTo("token github123")
+                    );
+                    MatcherAssert.assertThat(
+                        req.getMethod(),
+                        Matchers.equalTo("GET")
+                    );
+                    MatcherAssert.assertThat(
+                        req.getUri().toString(),
+                        Matchers.equalTo(
+                            "http://localhost/repos/mihai/test/commits/123"
+                        )
+                    );
+                    return new MockJsonResources.MockResource(
+                        HttpURLConnection.HTTP_OK,
+                        Json.createObjectBuilder()
+                            .add("sha", "123")
+                            .add(
+                                "author",
+                                Json.createObjectBuilder()
+                                    .add("login", "mihai")
+                            ).build()
+                    );
+                }
+            ),
+            URI.create("http://localhost/repos/mihai/test/commits"),
+            Mockito.mock(Storage.class)
+        );
+        final Commit found = commits.getCommit("123");
+        MatcherAssert.assertThat(
+            found.author(),
+            Matchers.equalTo("mihai")
+        );
+    }
+
+    /**
+     * GithubCommit can return null if the commit is not found.
+     */
+    @Test
+    public void getNullCommit() {
+        final Commits commits = new GithubCommits(
+            new MockJsonResources(
+                new AccessToken.Github("github123"),
+                req -> {
+                    MatcherAssert.assertThat(
+                        req.getAccessToken().value(),
+                        Matchers.equalTo("token github123")
+                    );
+                    MatcherAssert.assertThat(
+                        req.getMethod(),
+                        Matchers.equalTo("GET")
+                    );
+                    MatcherAssert.assertThat(
+                        req.getUri().toString(),
+                        Matchers.equalTo(
+                            "http://localhost/repos/mihai/test/commits/123"
+                        )
+                    );
+                    return new MockJsonResources.MockResource(
+                        422,
+                        Json.createObjectBuilder().build()
+                    );
+                }
+            ),
+            URI.create("http://localhost/repos/mihai/test/commits"),
+            Mockito.mock(Storage.class)
+        );
+        final Commit found = commits.getCommit("123");
+        MatcherAssert.assertThat(
+            found,
+            Matchers.nullValue()
+        );
+    }
+
+    /**
+     * GithubCommit throws an exception if getCommit received 500 SERVER ERROR.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void getCommitThrowsException() {
+        final Commits commits = new GithubCommits(
+            new MockJsonResources(
+                new AccessToken.Github("github123"),
+                req -> {
+                    MatcherAssert.assertThat(
+                        req.getAccessToken().value(),
+                        Matchers.equalTo("token github123")
+                    );
+                    MatcherAssert.assertThat(
+                        req.getMethod(),
+                        Matchers.equalTo("GET")
+                    );
+                    MatcherAssert.assertThat(
+                        req.getUri().toString(),
+                        Matchers.equalTo(
+                            "http://localhost/repos/mihai/test/commits/123"
+                        )
+                    );
+                    return new MockJsonResources.MockResource(
+                        HttpURLConnection.HTTP_INTERNAL_ERROR,
+                        Json.createObjectBuilder().build()
+                    );
+                }
+            ),
+            URI.create("http://localhost/repos/mihai/test/commits"),
+            Mockito.mock(Storage.class)
+        );
+        commits.getCommit("123");
+    }
+}

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubRepoTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubRepoTestCase.java
@@ -120,6 +120,26 @@ public final class GithubRepoTestCase {
     }
 
     /**
+     * A GithubRepo can return its Commits.
+     */
+    @Test
+    public void returnsCommits() {
+        final Repo repo = new GithubRepo(
+            Mockito.mock(JsonResources.class),
+            URI.create("http://localhost:8080/repos/mihai/test/"),
+            Mockito.mock(User.class),
+            Mockito.mock(Storage.class)
+        );
+        MatcherAssert.assertThat(
+            repo.commits(),
+            Matchers.allOf(
+                Matchers.notNullValue(),
+                Matchers.instanceOf(GithubCommits.class)
+            )
+        );
+    }
+
+    /**
      * A GithubRepo can be activated.
      */
     @Test


### PR DESCRIPTION
Fixes #646 

Implemented Github Commits - get and receive a Commit.
Implemented Github Commit Comments - post a comment in a commit or receive a commit comment
Wrote unit tests