### PR TITLE
#651 changed GithubIssue.isPullRequest() logic

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssue.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssue.java
@@ -268,7 +268,8 @@ final class GithubIssue implements Issue {
 
     @Override
     public boolean isPullRequest() {
-        return this.json.getJsonObject("pull_request") != null;
+        return this.json.getString("html_url")
+            .endsWith("/pull/" + this.issueId());
     }
 
     @Override

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssueTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssueTestCase.java
@@ -78,7 +78,10 @@ public final class GithubIssueTestCase {
     public void returnsDevRole() {
         final Issue issue = new GithubIssue(
             URI.create("http://localhost/issues/1"),
-            Json.createObjectBuilder().add("number", 1).build(),
+            Json.createObjectBuilder()
+                .add("number", 1)
+                .add("html_url", "http://localhost/issues/1")
+                .build(),
             Mockito.mock(Storage.class),
             Mockito.mock(JsonResources.class)
         );
@@ -94,10 +97,10 @@ public final class GithubIssueTestCase {
     @Test
     public void returnsRevRole() {
         final Issue issue = new GithubIssue(
-            URI.create("http://localhost/issues/1"),
+            URI.create("http://localhost/pull/1"),
             Json.createObjectBuilder()
                 .add("number", 1)
-                .add("pull_request", Json.createObjectBuilder())
+                .add("html_url", "http://localhost/pull/1")
                 .build(),
             Mockito.mock(Storage.class),
             Mockito.mock(JsonResources.class)
@@ -180,7 +183,10 @@ public final class GithubIssueTestCase {
     public void returnsIssueEstimation() {
         final int estimation = new GithubIssue(
             URI.create("http://localhost/issues/1"),
-            JsonObject.EMPTY_JSON_OBJECT,
+            Json.createObjectBuilder()
+                .add("number", 1)
+                .add("html_url", "http://localhost/issues/1")
+                .build(),
             Mockito.mock(Storage.class),
             Mockito.mock(JsonResources.class)
         ).estimation();
@@ -193,9 +199,10 @@ public final class GithubIssueTestCase {
     @Test
     public void returnsPullRequestEstimation() {
         final int estimation = new GithubIssue(
-            URI.create("http://localhost/issues/1"),
+            URI.create("http://localhost/pull/1"),
             Json.createObjectBuilder()
-                .add("pull_request", Json.createObjectBuilder())
+                .add("number", 1)
+                .add("html_url", "http://localhost/pull/1")
                 .build(),
             Mockito.mock(Storage.class),
             Mockito.mock(JsonResources.class)


### PR DESCRIPTION
PR for #651

We needed to change this logic because the JSON that comes from the Webhook pull_request event does not have the ``pull_request`` child object.
