### PR TITLE
#689 add or remove contributor label

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/storage/Labels.java
+++ b/self-api/src/main/java/com/selfxdsd/api/storage/Labels.java
@@ -29,6 +29,8 @@ import com.selfxdsd.api.Label;
  * @author criske
  * @version $Id$
  * @since 0.0.30
+ * @todo #689:30min Implement and test GithubRepoLabels, which will
+ *  represent all the labels defined in a Repo.
  */
 public interface Labels extends Iterable<Label> {
 
@@ -37,5 +39,12 @@ public interface Labels extends Iterable<Label> {
      * @param names Array of names.
      * @return True if successfully added.
      */
-    boolean add(final String ...names);
+    boolean add(final String... names);
+
+    /**
+     * Remove a label.
+     * @param name Label to be removed.
+     * @return True if successfully removed.
+     */
+    boolean remove(final String name);
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssueLabels.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssueLabels.java
@@ -24,6 +24,8 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Label;
 import com.selfxdsd.api.storage.Labels;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
@@ -41,6 +43,13 @@ import java.util.stream.Collectors;
  * @since 0.0.30
  */
 final class GithubIssueLabels implements Labels {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(
+        GithubIssueLabels.class
+    );
 
     /**
      * Issue Labels URI.
@@ -74,6 +83,31 @@ final class GithubIssueLabels implements Labels {
             .build()
         );
         return resource.statusCode() == HttpURLConnection.HTTP_OK;
+    }
+
+    @Override
+    public boolean remove(final String name) {
+        final URI labelUri = URI.create(this.uri.toString() + "/" + name);
+        LOG.debug("Removing Issue Label [" + labelUri + "]...");
+        final Resource resource = this.resources.delete(
+            labelUri,
+            Json.createObjectBuilder().build()
+        );
+        final int status = resource.statusCode();
+        final boolean result;
+        if(status == HttpURLConnection.HTTP_OK) {
+            result = true;
+            LOG.debug("Label Issue removed successfully (200 OK).");
+        } else if (status == HttpURLConnection.HTTP_NOT_FOUND) {
+            result = true;
+            LOG.warn("Label Issue NOT FOUND (still valid).");
+        } else {
+            result = false;
+            LOG.error(
+                "Unexpected response. Expected 200 or 404, but got: " + status
+            );
+        }
+        return result;
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssues.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssues.java
@@ -106,11 +106,13 @@ final class GithubIssues implements Issues {
         }
         Issue issue = null;
         if(jsonObject != null){
-            issue = new GithubIssue(
-                issueUri,
-                jsonObject,
-                this.storage,
-                this.resources
+            issue = new WithContributorLabel(
+                new GithubIssue(
+                    issueUri,
+                    jsonObject,
+                    this.storage,
+                    this.resources
+                )
             );
         }
         return issue;
@@ -118,13 +120,15 @@ final class GithubIssues implements Issues {
 
     @Override
     public Issue received(final JsonObject issue) {
-        return new GithubIssue(
-            URI.create(
-                this.issuesUri.toString() + "/" + issue.getInt("number")
-            ),
-            issue,
-            this.storage,
-            this.resources
+        return new WithContributorLabel(
+            new GithubIssue(
+                URI.create(
+                    this.issuesUri.toString() + "/" + issue.getInt("number")
+                ),
+                issue,
+                this.storage,
+                this.resources
+            )
         );
     }
 
@@ -161,14 +165,16 @@ final class GithubIssues implements Issues {
         }
         Issue issue = null;
         if(jsonObject != null){
-            issue = new GithubIssue(
-                URI.create(
-                    this.issuesUri.toString() + "/"
-                    + jsonObject.getInt("number")
-                ),
-                jsonObject,
-                this.storage,
-                this.resources
+            issue = new WithContributorLabel(
+                new GithubIssue(
+                    URI.create(
+                        this.issuesUri.toString() + "/"
+                        + jsonObject.getInt("number")
+                    ),
+                    jsonObject,
+                    this.storage,
+                    this.resources
+                )
             );
         }
         return issue;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/WithContributorLabel.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/WithContributorLabel.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Comments;
+import com.selfxdsd.api.Issue;
+import com.selfxdsd.api.storage.Labels;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.json.JsonObject;
+
+/**
+ * Issue decorator which adds or removes a label with the contributor's tag
+ * when the issue is assigned or unassigned.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.34
+ */
+final class WithContributorLabel implements Issue {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(
+        WithContributorLabel.class
+    );
+
+    /**
+     * Decorated Issue.
+     */
+    private final Issue decorated;
+
+    /**
+     * Ctor.
+     * @param decorated Decorated issue.
+     */
+    WithContributorLabel(final Issue decorated) {
+        this.decorated = decorated;
+    }
+
+    @Override
+    public String issueId() {
+        return this.decorated.issueId();
+    }
+
+    @Override
+    public String provider() {
+        return this.decorated.provider();
+    }
+
+    @Override
+    public String role() {
+        return this.decorated.role();
+    }
+
+    @Override
+    public String repoFullName() {
+        return this.decorated.repoFullName();
+    }
+
+    @Override
+    public String author() {
+        return this.decorated.author();
+    }
+
+    @Override
+    public String body() {
+        return this.decorated.body();
+    }
+
+    @Override
+    public String assignee() {
+        return this.decorated.assignee();
+    }
+
+    @Override
+    public boolean assign(final String username) {
+        final boolean assigned = this.decorated.assign(username);
+        if(assigned) {
+            LOG.debug("Adding label @" + username + "... ");
+            boolean labeled = this.labels().add("@" + username);
+            if(labeled) {
+                LOG.debug("Label added.");
+            } else {
+                LOG.warn("Problem while adding label.");
+            }
+        }
+        return assigned;
+    }
+
+    @Override
+    public boolean unassign(final String username) {
+        final boolean unassigned = this.decorated.unassign(username);
+        if(unassigned) {
+            LOG.debug("Removing label @" + username + "... ");
+            boolean removed = this.labels().remove("@" + username);
+            if(removed) {
+                LOG.debug("Label removed.");
+            } else {
+                LOG.warn("Problem while removing label.");
+            }
+        }
+        return unassigned;
+    }
+
+    @Override
+    public JsonObject json() {
+        return this.decorated.json();
+    }
+
+    @Override
+    public Comments comments() {
+        return this.decorated.comments();
+    }
+
+    @Override
+    public void close() {
+        this.decorated.close();
+    }
+
+    @Override
+    public void reopen() {
+        this.decorated.reopen();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return this.decorated.isClosed();
+    }
+
+    @Override
+    public boolean isPullRequest() {
+        return this.decorated.isPullRequest();
+    }
+
+    @Override
+    public int estimation() {
+        return this.decorated.estimation();
+    }
+
+    @Override
+    public Labels labels() {
+        return this.decorated.labels();
+    }
+}

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssueLabelsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssueLabelsTestCase.java
@@ -92,4 +92,43 @@ public final class GithubIssueLabelsTestCase {
                 .build()
             ).build()));
     }
+
+    /**
+     * A GithubIssueLabels can remove an Issue Label.
+     */
+    @Test
+    public void canRemoveLabel(){
+        final MockJsonResources resources =
+            new MockJsonResources(
+                req -> new MockJsonResources.MockResource(
+                    200,
+                    JsonValue.NULL
+                )
+            );
+
+        final URI issueLabelsUri = URI.create(
+            "https://api.github.com/repos/amihaiemil"
+            + "/docker-java-api/issues/labels"
+        );
+
+        final Labels issueLabels = new GithubIssueLabels(
+            issueLabelsUri, resources
+        );
+        MatcherAssert.assertThat(
+            issueLabels.remove("bug"),
+            Matchers.is(true)
+        );
+        MockJsonResources.MockRequest request = resources.requests().first();
+        MatcherAssert.assertThat(
+            request.getMethod(), Matchers.equalTo("DELETE")
+        );
+        MatcherAssert.assertThat(
+            request.getUri(),
+            Matchers.equalTo(URI.create(issueLabelsUri.toString() + "/bug"))
+        );
+        MatcherAssert.assertThat(
+            request.getBody(),
+            Matchers.equalTo(Json.createObjectBuilder().build())
+        );
+    }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/WithContributorLabelTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/WithContributorLabelTestCase.java
@@ -1,0 +1,336 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Comments;
+import com.selfxdsd.api.Issue;
+import com.selfxdsd.api.Provider;
+import com.selfxdsd.api.storage.Labels;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+
+/**
+ * Unit tests for {@link WithContributorLabel}.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.34
+ */
+public final class WithContributorLabelTestCase {
+
+    /**
+     * WithContributorLabel adds the label if the assignment
+     * is successful.
+     */
+    @Test
+    public void addsLabelOnAssignmentOk() {
+        final Labels labels = Mockito.mock(Labels.class);
+        final Issue decorated = Mockito.mock(Issue.class);
+        Mockito.when(decorated.labels()).thenReturn(labels);
+        Mockito.when(decorated.assign("mihai")).thenReturn(true);
+        final Issue withLabel = new WithContributorLabel(decorated);
+        MatcherAssert.assertThat(
+            withLabel.assign("mihai"),
+            Matchers.is(true)
+        );
+        Mockito.verify(labels, Mockito.times(1)).add("@mihai");
+    }
+
+    /**
+     * WithContributorLabel does not add the label if the assignment
+     * is unsuccessful.
+     */
+    @Test
+    public void doesNotAddLabelOnAssignmentFailed() {
+        final Labels labels = Mockito.mock(Labels.class);
+        final Issue decorated = Mockito.mock(Issue.class);
+        Mockito.when(decorated.labels()).thenReturn(labels);
+        Mockito.when(decorated.assign("mihai")).thenReturn(false);
+        final Issue withLabel = new WithContributorLabel(decorated);
+        MatcherAssert.assertThat(
+            withLabel.assign("mihai"),
+            Matchers.is(false)
+        );
+        Mockito.verify(labels, Mockito.times(0)).add(Mockito.anyString());
+    }
+
+    /**
+     * WithContributorLabel removes the label if the unassignment
+     * is successful.
+     */
+    @Test
+    public void removesLabelOnUnassignmentOk() {
+        final Labels labels = Mockito.mock(Labels.class);
+        final Issue decorated = Mockito.mock(Issue.class);
+        Mockito.when(decorated.labels()).thenReturn(labels);
+        Mockito.when(decorated.unassign("mihai")).thenReturn(true);
+        final Issue withLabel = new WithContributorLabel(decorated);
+        MatcherAssert.assertThat(
+            withLabel.unassign("mihai"),
+            Matchers.is(true)
+        );
+        Mockito.verify(labels, Mockito.times(1)).remove("@mihai");
+    }
+
+    /**
+     * WithContributorLabel does not remove the label if the unassignment
+     * is unsuccessful.
+     */
+    @Test
+    public void doesNotRemoveLabelOnUnassignmentFailed() {
+        final Labels labels = Mockito.mock(Labels.class);
+        final Issue decorated = Mockito.mock(Issue.class);
+        Mockito.when(decorated.labels()).thenReturn(labels);
+        Mockito.when(decorated.unassign("mihai")).thenReturn(false);
+        final Issue withLabel = new WithContributorLabel(decorated);
+        MatcherAssert.assertThat(
+            withLabel.unassign("mihai"),
+            Matchers.is(false)
+        );
+        Mockito.verify(labels, Mockito.times(0)).remove(Mockito.anyString());
+    }
+
+    /**
+     * Delegates the issueId to the decorated object.
+     */
+    @Test
+    public void delegatesIssueId() {
+        final Issue decorated = Mockito.mock(Issue.class);
+        Mockito.when(decorated.issueId()).thenReturn("123");
+        final Issue withLabel = new WithContributorLabel(decorated);
+        MatcherAssert.assertThat(
+            withLabel.issueId(),
+            Matchers.equalTo("123")
+        );
+        Mockito.verify(decorated, Mockito.times(1)).issueId();
+    }
+
+    /**
+     * Delegates the provider to the decorated object.
+     */
+    @Test
+    public void delegatesProvider() {
+        final Issue decorated = Mockito.mock(Issue.class);
+        Mockito.when(decorated.provider()).thenReturn(Provider.Names.GITHUB);
+        final Issue withLabel = new WithContributorLabel(decorated);
+        MatcherAssert.assertThat(
+            withLabel.provider(),
+            Matchers.equalTo(Provider.Names.GITHUB)
+        );
+        Mockito.verify(decorated, Mockito.times(1)).provider();
+    }
+
+    /**
+     * Delegates the role to the decorated object.
+     */
+    @Test
+    public void delegatesRole() {
+        final Issue decorated = Mockito.mock(Issue.class);
+        Mockito.when(decorated.role()).thenReturn("DEV");
+        final Issue withLabel = new WithContributorLabel(decorated);
+        MatcherAssert.assertThat(
+            withLabel.role(),
+            Matchers.equalTo("DEV")
+        );
+        Mockito.verify(decorated, Mockito.times(1)).role();
+    }
+
+    /**
+     * Delegates the repoFullName to the decorated object.
+     */
+    @Test
+    public void delegatesRepoFullName() {
+        final Issue decorated = Mockito.mock(Issue.class);
+        Mockito.when(decorated.repoFullName()).thenReturn("mihai/test");
+        final Issue withLabel = new WithContributorLabel(decorated);
+        MatcherAssert.assertThat(
+            withLabel.repoFullName(),
+            Matchers.equalTo("mihai/test")
+        );
+        Mockito.verify(decorated, Mockito.times(1)).repoFullName();
+    }
+
+    /**
+     * Delegates the author to the decorated object.
+     */
+    @Test
+    public void delegatesAuthor() {
+        final Issue decorated = Mockito.mock(Issue.class);
+        Mockito.when(decorated.author()).thenReturn("mihai");
+        final Issue withLabel = new WithContributorLabel(decorated);
+        MatcherAssert.assertThat(
+            withLabel.author(),
+            Matchers.equalTo("mihai")
+        );
+        Mockito.verify(decorated, Mockito.times(1)).author();
+    }
+
+    /**
+     * Delegates the body to the decorated object.
+     */
+    @Test
+    public void delegatesBody() {
+        final Issue decorated = Mockito.mock(Issue.class);
+        Mockito.when(decorated.body()).thenReturn("some issue...");
+        final Issue withLabel = new WithContributorLabel(decorated);
+        MatcherAssert.assertThat(
+            withLabel.body(),
+            Matchers.equalTo("some issue...")
+        );
+        Mockito.verify(decorated, Mockito.times(1)).body();
+    }
+
+    /**
+     * Delegates the assignee to the decorated object.
+     */
+    @Test
+    public void delegatesAssignee() {
+        final Issue decorated = Mockito.mock(Issue.class);
+        Mockito.when(decorated.assignee()).thenReturn("john");
+        final Issue withLabel = new WithContributorLabel(decorated);
+        MatcherAssert.assertThat(
+            withLabel.assignee(),
+            Matchers.equalTo("john")
+        );
+        Mockito.verify(decorated, Mockito.times(1)).assignee();
+    }
+
+    /**
+     * Delegates the json to the decorated object.
+     */
+    @Test
+    public void delegatesJson() {
+        final JsonObject json = Json.createObjectBuilder().build();
+        final Issue decorated = Mockito.mock(Issue.class);
+        Mockito.when(decorated.json()).thenReturn(json);
+        final Issue withLabel = new WithContributorLabel(decorated);
+        MatcherAssert.assertThat(
+            withLabel.json(),
+            Matchers.equalTo(json)
+        );
+        Mockito.verify(decorated, Mockito.times(1)).json();
+    }
+
+    /**
+     * Delegates the comments to the decorated object.
+     */
+    @Test
+    public void delegatesComments() {
+        final Comments comments = Mockito.mock(Comments.class);
+        final Issue decorated = Mockito.mock(Issue.class);
+        Mockito.when(decorated.comments()).thenReturn(comments);
+        final Issue withLabel = new WithContributorLabel(decorated);
+        MatcherAssert.assertThat(
+            withLabel.comments(),
+            Matchers.is(comments)
+        );
+        Mockito.verify(decorated, Mockito.times(1)).comments();
+    }
+
+    /**
+     * Delegates the isClosed to the decorated object.
+     */
+    @Test
+    public void delegatesIsClosed() {
+        final Issue decorated = Mockito.mock(Issue.class);
+        Mockito.when(decorated.isClosed()).thenReturn(true);
+        final Issue withLabel = new WithContributorLabel(decorated);
+        MatcherAssert.assertThat(
+            withLabel.isClosed(),
+            Matchers.is(true)
+        );
+        Mockito.verify(decorated, Mockito.times(1)).isClosed();
+    }
+
+    /**
+     * Delegates the isPullRequest to the decorated object.
+     */
+    @Test
+    public void delegatesIsPullRequest() {
+        final Issue decorated = Mockito.mock(Issue.class);
+        Mockito.when(decorated.isPullRequest()).thenReturn(true);
+        final Issue withLabel = new WithContributorLabel(decorated);
+        MatcherAssert.assertThat(
+            withLabel.isPullRequest(),
+            Matchers.is(true)
+        );
+        Mockito.verify(decorated, Mockito.times(1)).isPullRequest();
+    }
+
+    /**
+     * Delegates the estimation to the decorated object.
+     */
+    @Test
+    public void delegatesEstimation() {
+        final Issue decorated = Mockito.mock(Issue.class);
+        Mockito.when(decorated.estimation()).thenReturn(45);
+        final Issue withLabel = new WithContributorLabel(decorated);
+        MatcherAssert.assertThat(
+            withLabel.estimation(),
+            Matchers.is(45)
+        );
+        Mockito.verify(decorated, Mockito.times(1)).estimation();
+    }
+
+    /**
+     * Delegates the labels to the decorated object.
+     */
+    @Test
+    public void delegatesLabels() {
+        final Labels labels = Mockito.mock(Labels.class);
+        final Issue decorated = Mockito.mock(Issue.class);
+        Mockito.when(decorated.labels()).thenReturn(labels);
+        final Issue withLabel = new WithContributorLabel(decorated);
+        MatcherAssert.assertThat(
+            withLabel.labels(),
+            Matchers.is(labels)
+        );
+        Mockito.verify(decorated, Mockito.times(1)).labels();
+    }
+
+    /**
+     * Delegates close to the decorated object.
+     */
+    @Test
+    public void delegatesClose() {
+        final Issue decorated = Mockito.mock(Issue.class);
+        final Issue withLabel = new WithContributorLabel(decorated);
+        withLabel.close();
+        Mockito.verify(decorated, Mockito.times(1)).close();
+    }
+
+    /**
+     * Delegates reopen to the decorated object.
+     */
+    @Test
+    public void delegatesReopen() {
+        final Issue decorated = Mockito.mock(Issue.class);
+        final Issue withLabel = new WithContributorLabel(decorated);
+        withLabel.reopen();
+        Mockito.verify(decorated, Mockito.times(1)).reopen();
+    }
+}


### PR DESCRIPTION
Fixes #689 

* Added and tested WithContributorLabel issue decorator
* Contributor tag (e.g. ``@amihaiemil``) is now added/removed when the issue is assigned/unassigned
* Left puzzle for GithubRepoLabels.