### PR TITLE
#711 Manager Commission as Percentage

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/ProjectManager.java
+++ b/self-api/src/main/java/com/selfxdsd/api/ProjectManager.java
@@ -71,11 +71,19 @@ public interface ProjectManager {
     Projects projects();
 
     /**
-     * The commission that this PM will earn for every handled
-     * Task, in cents.
-     * @return BigDecimal.
+     * The commission percentage that this PM will earn for every handled
+     * Task.
+     * @return Double.
      */
-    BigDecimal commission();
+    double percentage();
+
+    /**
+     * Calculate the effective commission that the PM will earn for a sum
+     * of money, in cents.
+     * @param value Commissioned value, in cents.
+     * @return Effective commission, in cents.
+     */
+    BigDecimal commission(final BigDecimal value);
 
     /**
      * Handle the "activate" (new project registered) event.

--- a/self-api/src/main/java/com/selfxdsd/api/ProjectManagers.java
+++ b/self-api/src/main/java/com/selfxdsd/api/ProjectManagers.java
@@ -22,8 +22,6 @@
  */
 package com.selfxdsd.api;
 
-import java.math.BigDecimal;
-
 /**
  * Project Managers API.
  * @author Mihai Andronache (amihaiemil@gmail.com)
@@ -60,8 +58,8 @@ public interface ProjectManagers extends Iterable<ProjectManager> {
      * @param username User name.
      * @param provider Provider name.
      * @param accessToken Access token.
-     * @param commission Commission that this PM will earn
-     *  for each Task it deals with.
+     * @param percentage Commission percentage that this PM takes for
+     *  each invoiced task.
      * @return The registered ProjectManager.
      */
     ProjectManager register(
@@ -69,6 +67,6 @@ public interface ProjectManagers extends Iterable<ProjectManager> {
         final String username,
         final String provider,
         final String accessToken,
-        final BigDecimal commission
+        final double percentage
     );
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contracts/StoredContract.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contracts/StoredContract.java
@@ -207,13 +207,12 @@ public final class StoredContract implements Contract {
     @Override
     public BigDecimal value() {
         BigDecimal total = BigDecimal.valueOf(0);
-        final BigDecimal commission = this.project()
-            .projectManager()
-            .commission();
+        final ProjectManager manager = this.project()
+            .projectManager();
         for(final Task task : this.tasks()) {
             total = total
                 .add(task.value())
-                .add(commission);
+                .add(manager.commission(task.value()));
         }
         total = total.add(this.invoices().active().totalAmount());
         return total;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contributors/ProjectContributors.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contributors/ProjectContributors.java
@@ -225,20 +225,20 @@ public final class ProjectContributors extends BasePaged
                 .noneMatch(r -> r.contributor().equals(contributor)))
             .filter(
                 contributor -> {
+                    final ProjectManager manager = this.project
+                        .projectManager();
                     for(final Contract contract : contributor.contracts()) {
                         if(contract.role().equals(task.role())
                             && contract.markedForRemoval() == null
                         ) {
-                            final BigDecimal price = contract.hourlyRate()
+                            BigDecimal price = contract.hourlyRate()
                                 .multiply(
                                     BigDecimal.valueOf(task.estimation())
                                 ).divide(
                                     BigDecimal.valueOf(60),
                                     RoundingMode.HALF_UP
-                                ).add(this.project
-                                    .projectManager()
-                                    .commission()
                                 );
+                            price = price.add(manager.commission(price));
                             final BigDecimal budget = this.project
                                 .wallet()
                                 .available();

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contracts/StoredContractTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contracts/StoredContractTestCase.java
@@ -363,7 +363,13 @@ public final class StoredContractTestCase {
         ).thenReturn(invoices);
 
         final ProjectManager manager = Mockito.mock(ProjectManager.class);
-        Mockito.when(manager.commission()).thenReturn(BigDecimal.valueOf(50));
+        Mockito.when(manager.percentage()).thenReturn(8.0);
+        Mockito.when(manager.commission(BigDecimal.valueOf(10000)))
+            .thenReturn(BigDecimal.valueOf(800));
+        Mockito.when(manager.commission(BigDecimal.valueOf(15000)))
+            .thenReturn(BigDecimal.valueOf(1200));
+        Mockito.when(manager.commission(BigDecimal.valueOf(7500)))
+            .thenReturn(BigDecimal.valueOf(600));
 
         final Projects allProjects = Mockito.mock(Projects.class);
         final Project project = Mockito.mock(Project.class);
@@ -391,7 +397,7 @@ public final class StoredContractTestCase {
 
         MatcherAssert.assertThat(
             contract.value(),
-            Matchers.equalTo(BigDecimal.valueOf(44950))
+            Matchers.equalTo(BigDecimal.valueOf(47400))
         );
     }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contributors/ProjectContributorsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contributors/ProjectContributorsTestCase.java
@@ -58,7 +58,7 @@ public final class ProjectContributorsTestCase {
                 "john/test",
                 Provider.Names.GITHUB,
                 BigDecimal.valueOf(100000),
-                BigDecimal.valueOf(1000)
+                8
             ),
             List.of(Mockito.mock(Contributor.class),
                 Mockito.mock(Contributor.class),
@@ -78,7 +78,7 @@ public final class ProjectContributorsTestCase {
                 "john/test",
                 Provider.Names.GITHUB,
                 BigDecimal.valueOf(100000),
-                BigDecimal.valueOf(1000)
+                8
             ),
             () -> IntStream.rangeClosed(1, 50)
                 .mapToObj(i -> Mockito.mock(Contributor.class)),
@@ -106,7 +106,7 @@ public final class ProjectContributorsTestCase {
                 "john/test",
                 Provider.Names.GITHUB,
                 BigDecimal.valueOf(100000),
-                BigDecimal.valueOf(1000)
+                8
             ),
             Stream::empty,
             Mockito.mock(Storage.class)
@@ -134,7 +134,7 @@ public final class ProjectContributorsTestCase {
                 "john/test",
                 Provider.Names.GITHUB,
                 BigDecimal.valueOf(100000),
-                BigDecimal.valueOf(1000)
+                8
             ),
             List.of(vlad, mihai)::stream,
             Mockito.mock(Storage.class)
@@ -155,7 +155,7 @@ public final class ProjectContributorsTestCase {
                 "john/test",
                 Provider.Names.GITHUB,
                 BigDecimal.valueOf(100000),
-                BigDecimal.valueOf(1000)
+                8
             ),
             List.of(Mockito.mock(Contributor.class),
                 Mockito.mock(Contributor.class),
@@ -179,7 +179,7 @@ public final class ProjectContributorsTestCase {
                 "john/test",
                 Provider.Names.GITHUB,
                 BigDecimal.valueOf(100000),
-                BigDecimal.valueOf(1000)
+                8
             ),
             List.of(Mockito.mock(Contributor.class),
                 Mockito.mock(Contributor.class),
@@ -202,7 +202,7 @@ public final class ProjectContributorsTestCase {
                 "john/test",
                 Provider.Names.GITHUB,
                 BigDecimal.valueOf(100000),
-                BigDecimal.valueOf(1000)
+                8
             ),
             List.of(Mockito.mock(Contributor.class),
                 Mockito.mock(Contributor.class),
@@ -225,7 +225,7 @@ public final class ProjectContributorsTestCase {
                 "john/test",
                 Provider.Names.GITHUB,
                 BigDecimal.valueOf(100000),
-                BigDecimal.valueOf(1000)
+                8
             ),
             List.of(vlad)::stream,
             Mockito.mock(Storage.class)
@@ -270,7 +270,7 @@ public final class ProjectContributorsTestCase {
                 "john/test",
                 Provider.Names.GITHUB,
                 BigDecimal.valueOf(100000),
-                BigDecimal.valueOf(1000)
+                8
             ),
             allContributorsSrc::stream,
             storage
@@ -292,7 +292,7 @@ public final class ProjectContributorsTestCase {
             "john/test",
             Provider.Names.GITHUB,
             BigDecimal.valueOf(100000),
-            BigDecimal.valueOf(1000)
+            8
         );
         final Contributors contributors = new ProjectContributors(
             project,
@@ -321,7 +321,7 @@ public final class ProjectContributorsTestCase {
             "john/test",
             Provider.Names.GITHUB,
             BigDecimal.valueOf(100000),
-            BigDecimal.valueOf(1000)
+            8
         );
         final Contributor assignee = this.mockContributor(
             "mihai", BigDecimal.valueOf(10000),  project,
@@ -350,6 +350,8 @@ public final class ProjectContributorsTestCase {
         Mockito.when(task.assignee()).thenReturn(assignee);
         Mockito.when(task.role()).thenReturn("DEV");
         Mockito.when(task.project()).thenReturn(project);
+        Mockito.when(project.projectManager().commission(Mockito.any()))
+            .thenReturn(BigDecimal.valueOf(100));
         final Resignations resignations = Mockito.mock(Resignations.class);
         Mockito.when(task.resignations()).thenReturn(resignations);
         Mockito.when(resignations.spliterator())
@@ -379,7 +381,7 @@ public final class ProjectContributorsTestCase {
             "john/test",
             Provider.Names.GITHUB,
             BigDecimal.valueOf(100000),
-            BigDecimal.valueOf(1000)
+            8
         );
         final Contributors contributors = new ProjectContributors(
             project,
@@ -401,6 +403,8 @@ public final class ProjectContributorsTestCase {
         Mockito.when(task.assignee()).thenReturn(null);
         Mockito.when(task.role()).thenReturn("DEV");
         Mockito.when(task.project()).thenReturn(project);
+        Mockito.when(project.projectManager().commission(Mockito.any()))
+            .thenReturn(BigDecimal.valueOf(800));
         final Resignations resignations = Mockito.mock(Resignations.class);
         Mockito.when(task.resignations()).thenReturn(resignations);
         Mockito.when(resignations.spliterator())
@@ -427,7 +431,7 @@ public final class ProjectContributorsTestCase {
             "john/test",
             Provider.Names.GITHUB,
             BigDecimal.valueOf(100000),
-            BigDecimal.valueOf(1000)
+            8
         );
 
         final Contributor contributor = Mockito.mock(Contributor.class);
@@ -479,7 +483,7 @@ public final class ProjectContributorsTestCase {
             "john/test",
             Provider.Names.GITHUB,
             BigDecimal.valueOf(100000),
-            BigDecimal.valueOf(1000)
+            8
         );
         final Contributors contributors = new ProjectContributors(
             project,
@@ -502,6 +506,8 @@ public final class ProjectContributorsTestCase {
         Mockito.when(task.role()).thenReturn("DEV");
         Mockito.when(task.estimation()).thenReturn(60);
         Mockito.when(task.project()).thenReturn(project);
+        Mockito.when(project.projectManager().commission(Mockito.any()))
+            .thenReturn(BigDecimal.valueOf(0));
         final Resignations resignations = Mockito.mock(Resignations.class);
         Mockito.when(task.resignations()).thenReturn(resignations);
         Mockito.when(resignations.spliterator())
@@ -532,7 +538,7 @@ public final class ProjectContributorsTestCase {
             "john/test",
             Provider.Names.GITHUB,
             BigDecimal.valueOf(100),
-            BigDecimal.valueOf(1000)
+            8
         );
         final Contributors contributors = new ProjectContributors(
             project,
@@ -555,6 +561,8 @@ public final class ProjectContributorsTestCase {
         Mockito.when(task.role()).thenReturn("DEV");
         Mockito.when(task.estimation()).thenReturn(60);
         Mockito.when(task.project()).thenReturn(project);
+        Mockito.when(project.projectManager().commission(Mockito.any()))
+            .thenReturn(BigDecimal.valueOf(100));
         final Resignations resignations = Mockito.mock(Resignations.class);
         Mockito.when(task.resignations()).thenReturn(resignations);
         Mockito.when(resignations.spliterator())
@@ -577,7 +585,7 @@ public final class ProjectContributorsTestCase {
             "john/test",
             Provider.Names.GITHUB,
             BigDecimal.valueOf(15000),
-            BigDecimal.valueOf(600)
+            8
         );
         final Contributors contributors = new ProjectContributors(
             project,
@@ -591,6 +599,8 @@ public final class ProjectContributorsTestCase {
         Mockito.when(task.role()).thenReturn("DEV");
         Mockito.when(task.estimation()).thenReturn(60);
         Mockito.when(task.project()).thenReturn(project);
+        Mockito.when(project.projectManager().commission(Mockito.any()))
+            .thenReturn(BigDecimal.valueOf(600));
         final Resignations resignations = Mockito.mock(Resignations.class);
         Mockito.when(task.resignations()).thenReturn(resignations);
         Mockito.when(resignations.spliterator())
@@ -613,7 +623,7 @@ public final class ProjectContributorsTestCase {
             "john/test-other",
             Provider.Names.GITHUB,
             BigDecimal.valueOf(15000),
-            BigDecimal.valueOf(100)
+            8
         );
         final Contributors contributors = new ProjectContributors(
             contributorsProject,
@@ -627,7 +637,7 @@ public final class ProjectContributorsTestCase {
             "john/test",
             Provider.Names.GITHUB,
             BigDecimal.valueOf(15000),
-            BigDecimal.valueOf(100)
+            8
         );
         Mockito.when(task.project()).thenReturn(taskProject);
 
@@ -644,7 +654,7 @@ public final class ProjectContributorsTestCase {
             "john/test",
             Provider.Names.GITHUB,
             BigDecimal.valueOf(100000),
-            BigDecimal.valueOf(1000)
+            8
         );
         final Contributor contributor = this
             .mockContributor("mihai", BigDecimal.valueOf(10000),
@@ -684,7 +694,7 @@ public final class ProjectContributorsTestCase {
             "john/test",
             Provider.Names.GITHUB,
             BigDecimal.valueOf(100000),
-            BigDecimal.valueOf(1000)
+            8
         );
         final Contributor contributor = this
             .mockContributor("mihai", BigDecimal.valueOf(10000),
@@ -708,7 +718,7 @@ public final class ProjectContributorsTestCase {
             "john/test",
             Provider.Names.GITHUB,
             BigDecimal.valueOf(100000),
-            BigDecimal.valueOf(1000)
+            8
         );
         final Contributor contributor = this
             .mockContributor("mihai", BigDecimal.valueOf(10000),
@@ -762,14 +772,14 @@ public final class ProjectContributorsTestCase {
      * @param repoFullName Repo full name.
      * @param providerName Provider name.
      * @param budget Budget.
-     * @param pmCommission Pm's commission.
+     * @param pmCommission Pm's commission percentage.
      * @return Project.
      */
     private Project mockProject(
         final String repoFullName,
         final String providerName,
         final BigDecimal budget,
-        final BigDecimal pmCommission
+        final double pmCommission
     ) {
         final Project project = Mockito.mock(Project.class);
         Mockito.when(project.repoFullName()).thenReturn(repoFullName);
@@ -786,7 +796,7 @@ public final class ProjectContributorsTestCase {
 
         final ProjectManager projectManager = Mockito
             .mock(ProjectManager.class);
-        Mockito.when(projectManager.commission()).thenReturn(pmCommission);
+        Mockito.when(projectManager.percentage()).thenReturn(pmCommission);
         Mockito.when(project.projectManager()).thenReturn(projectManager);
 
         return project;

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contributors/ProviderContributorsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contributors/ProviderContributorsTestCase.java
@@ -164,7 +164,7 @@ public final class ProviderContributorsTestCase {
                 "john/test",
                 Provider.Names.GITHUB,
                 BigDecimal.valueOf(100000),
-                BigDecimal.valueOf(1000)
+                8
             ),
             List.of(vlad)::stream,
             Mockito.mock(Storage.class)
@@ -203,7 +203,7 @@ public final class ProviderContributorsTestCase {
             "john/test",
             Provider.Names.GITHUB,
             BigDecimal.valueOf(100000),
-            BigDecimal.valueOf(1000)
+            8
         );
         final Storage storage = Mockito.mock(Storage.class);
         final Projects allProjects = Mockito.mock(Projects.class);
@@ -305,14 +305,14 @@ public final class ProviderContributorsTestCase {
      * @param repoFullName Repo full name.
      * @param providerName Provider name.
      * @param budget Budget.
-     * @param pmCommission Pm's commission.
+     * @param pmCommission Pm's commission percentage.
      * @return Project.
      */
     private Project mockProject(
         final String repoFullName,
         final String providerName,
         final BigDecimal budget,
-        final BigDecimal pmCommission
+        final double pmCommission
     ) {
         final Project project = Mockito.mock(Project.class);
         Mockito.when(project.repoFullName()).thenReturn(repoFullName);
@@ -329,7 +329,7 @@ public final class ProviderContributorsTestCase {
 
         final ProjectManager projectManager = Mockito
             .mock(ProjectManager.class);
-        Mockito.when(projectManager.commission()).thenReturn(pmCommission);
+        Mockito.when(projectManager.percentage()).thenReturn(pmCommission);
         Mockito.when(project.projectManager()).thenReturn(projectManager);
 
         return project;

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
@@ -133,6 +133,65 @@ public final class StoredProjectManagerTestCase {
     }
 
     /**
+     * StoredProjectManager can calculate the effective commission
+     * for a certain sum, based on the encapsulated percentage.
+     */
+    @Test
+    public void returnsCommission() {
+        final ProjectManager fixed = new StoredProjectManager(
+            1,
+            "123",
+            "zoeself",
+            Provider.Names.GITHUB,
+            "123token",
+            8,
+            Mockito.mock(Storage.class)
+        );
+        MatcherAssert.assertThat(
+            fixed.commission(BigDecimal.valueOf(1000)),
+            Matchers.equalTo(BigDecimal.valueOf(80.0))
+        );
+        MatcherAssert.assertThat(
+            fixed.commission(BigDecimal.valueOf(10000)),
+            Matchers.equalTo(BigDecimal.valueOf(800.0))
+        );
+        MatcherAssert.assertThat(
+            fixed.commission(BigDecimal.valueOf(100)),
+            Matchers.equalTo(BigDecimal.valueOf(8.0))
+        );
+        MatcherAssert.assertThat(
+            fixed.commission(BigDecimal.valueOf(10)),
+            Matchers.equalTo(BigDecimal.valueOf(0.8))
+        );
+
+        final ProjectManager comma = new StoredProjectManager(
+            1,
+            "123",
+            "zoeself",
+            Provider.Names.GITHUB,
+            "123token",
+            8.6345,
+            Mockito.mock(Storage.class)
+        );
+        MatcherAssert.assertThat(
+            comma.commission(BigDecimal.valueOf(1000)).toString(),
+            Matchers.equalTo("86.30")
+        );
+        MatcherAssert.assertThat(
+            comma.commission(BigDecimal.valueOf(10000)).toString(),
+            Matchers.equalTo("863.00")
+        );
+        MatcherAssert.assertThat(
+            comma.commission(BigDecimal.valueOf(100)).toString(),
+            Matchers.equalTo("8.63")
+        );
+        MatcherAssert.assertThat(
+            comma.commission(BigDecimal.valueOf(10)).toString(),
+            Matchers.equalTo("0.86")
+        );
+    }
+
+    /**
      * StoredProjectManager returns its assigned projects.
      */
     @Test

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
@@ -60,7 +60,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "1s23token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(
@@ -80,7 +80,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "1s23token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(
@@ -100,7 +100,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(
@@ -113,22 +113,22 @@ public final class StoredProjectManagerTestCase {
     }
 
     /**
-     * StoredProjectManager returns its commission.
+     * StoredProjectManager returns its commission percentage.
      */
     @Test
-    public void returnsCommission() {
+    public void returnsPercentage() {
         final ProjectManager manager = new StoredProjectManager(
             1,
             "123",
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(
-            manager.commission(),
-            Matchers.equalTo(BigDecimal.valueOf(50))
+            manager.percentage(),
+            Matchers.equalTo(8.0)
         );
     }
 
@@ -150,7 +150,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             storage
         );
         MatcherAssert.assertThat(
@@ -229,7 +229,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             new InMemory()
         );
         final Project assigned = manager.assign(repo);
@@ -255,7 +255,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
         final Labels labels = Mockito.mock(Labels.class);
@@ -325,7 +325,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
         final Labels labels = Mockito.mock(Labels.class);
@@ -396,7 +396,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
         final Issue issue = Mockito.mock(Issue.class);
@@ -471,7 +471,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
         final Issue issue = Mockito.mock(Issue.class);
@@ -539,7 +539,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
         final Issue issue = Mockito.mock(Issue.class);
@@ -611,7 +611,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
         final Issue issue = Mockito.mock(Issue.class);
@@ -678,7 +678,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
         final Issue issue = Mockito.mock(Issue.class);
@@ -776,7 +776,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
 
@@ -819,7 +819,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
 
@@ -875,7 +875,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
 
@@ -947,7 +947,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
 
@@ -1020,7 +1020,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
 
@@ -1060,7 +1060,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
 
@@ -1090,7 +1090,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "1s23token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
         final ProjectManager managerTwo = new StoredProjectManager(
@@ -1099,7 +1099,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "1s23token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(manager, Matchers.equalTo(managerTwo));
@@ -1116,7 +1116,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "1s23token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
         final ProjectManager managerTwo = new StoredProjectManager(
@@ -1125,7 +1125,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "1s23token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(manager.hashCode(),
@@ -1153,7 +1153,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
         manager.assignedTasks(event);
@@ -1185,7 +1185,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class)
         );
         manager.assignedTasks(event);
@@ -1213,13 +1213,14 @@ public final class StoredProjectManagerTestCase {
 
         Mockito.when(task.assignee()).thenReturn(assignee);
         Mockito.when(task.issue()).thenReturn(issue);
+        Mockito.when(task.value()).thenReturn(BigDecimal.valueOf(1000));
 
         mocks.add(task);
 
         final InvoicedTask invoiced = Mockito.mock(InvoicedTask.class);
         final Invoice active = Mockito.mock(Invoice.class);
         Mockito.when(
-            active.register(task, BigDecimal.valueOf(50))
+            active.register(task, BigDecimal.valueOf(80.0))
         ).thenReturn(invoiced);
         final Invoices invoices = Mockito.mock(Invoices.class);
         Mockito.when(invoices.active()).thenReturn(active);
@@ -1255,7 +1256,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             storage
         );
         manager.assignedTasks(event);
@@ -1264,7 +1265,7 @@ public final class StoredProjectManagerTestCase {
         Mockito.verify(contract, Mockito.times(1)).invoices();
         Mockito.verify(invoices, Mockito.times(1)).active();
         Mockito.verify(active, Mockito.times(1))
-            .register(task, BigDecimal.valueOf(50));
+            .register(task, BigDecimal.valueOf(80.0));
         Mockito.verify(all, Mockito.times(1)).remove(task);
         Mockito.verify(comments, Mockito.times(1)).post(Mockito.anyString());
     }
@@ -1314,7 +1315,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class),
             now
         );
@@ -1370,7 +1371,7 @@ public final class StoredProjectManagerTestCase {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50),
+            8,
             Mockito.mock(Storage.class),
             now
         );

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryProjectManagers.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryProjectManagers.java
@@ -127,7 +127,7 @@ public final class InMemoryProjectManagers implements ProjectManagers {
             username,
             provider,
             accessToken,
-            commission,
+            0,
             this.storage
         );
         this.pms.put(id, projectManager);

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryProjectManagers.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryProjectManagers.java
@@ -26,7 +26,6 @@ import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
 import com.selfxdsd.core.managers.StoredProjectManager;
 
-import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -67,14 +66,14 @@ public final class InMemoryProjectManagers implements ProjectManagers {
             "zoeself",
             Provider.Names.GITHUB,
             "123token",
-            BigDecimal.valueOf(50)
+            8
         );
         register(
             "123",
             "zoeself",
             Provider.Names.GITLAB,
             "123token",
-            BigDecimal.valueOf(50)
+            8
         );
     }
 
@@ -118,7 +117,7 @@ public final class InMemoryProjectManagers implements ProjectManagers {
         final String username,
         final String provider,
         final String accessToken,
-        final BigDecimal commission
+        final double percentage
     ) {
         final int id = ++this.idCounter;
         final StoredProjectManager projectManager = new StoredProjectManager(
@@ -127,7 +126,7 @@ public final class InMemoryProjectManagers implements ProjectManagers {
             username,
             provider,
             accessToken,
-            0,
+            percentage,
             this.storage
         );
         this.pms.put(id, projectManager);

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryProjectManagersTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryProjectManagersTestCase.java
@@ -5,8 +5,6 @@ import com.selfxdsd.api.ProjectManagers;
 import com.selfxdsd.api.storage.Storage;
 import org.junit.Test;
 
-import java.math.BigDecimal;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.mock;
@@ -79,7 +77,7 @@ public final class InMemoryProjectManagersTestCase {
             "userpm",
             "foo-provider",
             "122token",
-            BigDecimal.valueOf(50)
+            8
         );
         assertThat(
             "Should have pms for: github, gitlab, foo-provider",
@@ -99,7 +97,7 @@ public final class InMemoryProjectManagersTestCase {
                 "userpm",
                 "foo-provider",
                 "122token",
-                BigDecimal.valueOf(50)
+                8
             );
         assertThat(projectManagers.getById(3), equalTo(projectManager));
     }


### PR DESCRIPTION
Fixes #711 

* StoredProjectManager takes commission as ``double``
* Method ProjectManager.percentage() to return the double percentage
* Method BigDecimal::ProjectManager.commission(...) to calculate the effective commission for a value
* Updated dependent code
* Updated tests (and added test for the new ``commission(...)`` method).

* Updated ProjectManagers.register(...) to accept the commission as double percentage.