### PR TITLE
#736 Estimation read from Labels

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Estimation.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Estimation.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.api;
+
+/**
+ * Estimation of a task in Self.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.39
+ */
+public interface Estimation {
+
+    /**
+     * Estimation in minutes.
+     * @return Integer.
+     */
+    int minutes();
+
+}

--- a/self-api/src/main/java/com/selfxdsd/api/Issue.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Issue.java
@@ -124,11 +124,10 @@ public interface Issue {
     boolean isPullRequest();
 
     /**
-     * The estimation in minutes for the given issue.
-     *
-     * @return Integer.
+     * The Estimation of this issue.
+     * @return Estimation.
      */
-    int estimation();
+    Estimation estimation();
 
     /**
      * Labels of this Issue.

--- a/self-api/src/main/java/com/selfxdsd/api/Wallet.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Wallet.java
@@ -63,7 +63,6 @@ public interface Wallet {
      * Pay an invoice.
      * @param invoice The Invoice to be paid.
      * @return Wallet having cash deducted with Invoice amount.
-     * @throws InvoiceException.AlreadyPaid If the Invoice is already paid.
      */
     Wallet pay(final Invoice invoice);
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssue.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssue.java
@@ -22,10 +22,7 @@
  */
 package com.selfxdsd.core;
 
-import com.selfxdsd.api.Comments;
-import com.selfxdsd.api.Contract;
-import com.selfxdsd.api.Issue;
-import com.selfxdsd.api.Labels;
+import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -279,14 +276,8 @@ final class GithubIssue implements Issue {
     }
 
     @Override
-    public int estimation() {
-        final int estimation;
-        if(this.isPullRequest()) {
-            estimation = 30;
-        } else {
-            estimation = 60;
-        }
-        return estimation;
+    public Estimation estimation() {
+        return new LabelsEstimation(this);
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabIssue.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabIssue.java
@@ -228,14 +228,8 @@ final class GitlabIssue implements Issue {
     }
 
     @Override
-    public int estimation() {
-        final int estimation;
-        if(this.isPullRequest()) {
-            estimation = 30;
-        } else {
-            estimation = 60;
-        }
-        return estimation;
+    public Estimation estimation() {
+        return new LabelsEstimation(this);
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/LabelsEstimation.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/LabelsEstimation.java
@@ -50,6 +50,11 @@ final class LabelsEstimation implements Estimation {
     private static final String ESTIMATION = "^([1-9]+[0-9]*)[ ]*(minutes|min|m)$";
 
     /**
+     * Maximum estimation allowed.
+     */
+    private static final int MAX_ESTIMATION = 360;
+
+    /**
      * Issue being estimated.
      */
     private final Issue issue;
@@ -82,6 +87,9 @@ final class LabelsEstimation implements Estimation {
             } else {
                 minutes = 60;
             }
+        }
+        if(minutes > MAX_ESTIMATION) {
+            minutes = MAX_ESTIMATION;
         }
         return minutes;
     }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/LabelsEstimation.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/LabelsEstimation.java
@@ -87,8 +87,7 @@ final class LabelsEstimation implements Estimation {
             } else {
                 minutes = 60;
             }
-        }
-        if(minutes > MAX_ESTIMATION) {
+        } else if(minutes > MAX_ESTIMATION) {
             minutes = MAX_ESTIMATION;
         }
         return minutes;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/LabelsEstimation.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/LabelsEstimation.java
@@ -55,6 +55,12 @@ final class LabelsEstimation implements Estimation {
     private static final int MAX_ESTIMATION = 360;
 
     /**
+     * Minimum estimation allowed.
+     */
+    private static final int MIN_ESTIMATION = 15;
+
+
+    /**
      * Issue being estimated.
      */
     private final Issue issue;
@@ -89,6 +95,8 @@ final class LabelsEstimation implements Estimation {
             }
         } else if(minutes > MAX_ESTIMATION) {
             minutes = MAX_ESTIMATION;
+        } else if(minutes < MIN_ESTIMATION) {
+            minutes = MIN_ESTIMATION;
         }
         return minutes;
     }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/LabelsEstimation.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/LabelsEstimation.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Estimation;
+import com.selfxdsd.api.Issue;
+import com.selfxdsd.api.Label;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Estimation of an Issue/PR read from its labels.<br><br>
+ *
+ * If no estimation Label is present, the default estimation is
+ * 60min for Issues and 30min for PRs.<br><br>
+ *
+ * Format of an estimation label should be 60 min|minutes|m.
+ *
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.39
+ */
+final class LabelsEstimation implements Estimation {
+
+    /**
+     * Label regex.
+     * @checkstyle LineLength (5 lines)
+     */
+    private static final String ESTIMATION = "^([1-9]+[0-9]*)[ ]*(minutes|min|m)$";
+
+    /**
+     * Issue being estimated.
+     */
+    private final Issue issue;
+
+    /**
+     * Ctor.
+     * @param issue Estimated issue.
+     */
+    LabelsEstimation(final Issue issue) {
+        this.issue = issue;
+    }
+
+    @Override
+    public int minutes() {
+        int minutes = 0;
+        final Pattern reg = Pattern.compile(
+            ESTIMATION,
+            Pattern.CASE_INSENSITIVE
+        );
+        for(final Label label : this.issue.labels()) {
+            final Matcher match = reg.matcher(label.name());
+            if(match.find()) {
+                minutes = Integer.valueOf(match.group(1));
+                break;
+            }
+        }
+        if(minutes == 0) {
+            if(this.issue.isPullRequest()) {
+                minutes = 30;
+            } else {
+                minutes = 60;
+            }
+        }
+        return minutes;
+    }
+}

--- a/self-core-impl/src/main/java/com/selfxdsd/core/WithContributorLabel.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/WithContributorLabel.java
@@ -23,6 +23,7 @@
 package com.selfxdsd.core;
 
 import com.selfxdsd.api.Comments;
+import com.selfxdsd.api.Estimation;
 import com.selfxdsd.api.Issue;
 import com.selfxdsd.api.Labels;
 import org.slf4j.Logger;
@@ -155,7 +156,7 @@ final class WithContributorLabel implements Issue {
     }
 
     @Override
-    public int estimation() {
+    public Estimation estimation() {
         return this.decorated.estimation();
     }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssueTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssueTestCase.java
@@ -229,11 +229,11 @@ public final class GithubIssueTestCase {
     }
 
     /**
-     * An Issue should have an estimation of 60 minutes.
+     * A GithubIssue can return its Estimation.
      */
     @Test
-    public void returnsIssueEstimation() {
-        final int estimation = new GithubIssue(
+    public void returnsEstimation() {
+        final Estimation estimation = new GithubIssue(
             URI.create("http://localhost/issues/1"),
             Json.createObjectBuilder()
                 .add("number", 1)
@@ -242,24 +242,13 @@ public final class GithubIssueTestCase {
             Mockito.mock(Storage.class),
             Mockito.mock(JsonResources.class)
         ).estimation();
-        MatcherAssert.assertThat(estimation, Matchers.is(60));
-    }
-
-    /**
-     * A Pull Request should have an estimation of 30 minutes.
-     */
-    @Test
-    public void returnsPullRequestEstimation() {
-        final int estimation = new GithubIssue(
-            URI.create("http://localhost/pull/1"),
-            Json.createObjectBuilder()
-                .add("number", 1)
-                .add("html_url", "http://localhost/pull/1")
-                .build(),
-            Mockito.mock(Storage.class),
-            Mockito.mock(JsonResources.class)
-        ).estimation();
-        MatcherAssert.assertThat(estimation, Matchers.is(30));
+        MatcherAssert.assertThat(
+            estimation,
+            Matchers.allOf(
+                Matchers.notNullValue(),
+                Matchers.instanceOf(LabelsEstimation.class)
+            )
+        );
     }
 
     /**

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabIssueTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabIssueTestCase.java
@@ -23,6 +23,7 @@
 package com.selfxdsd.core;
 
 import com.selfxdsd.api.Contract;
+import com.selfxdsd.api.Estimation;
 import com.selfxdsd.api.Issue;
 import com.selfxdsd.api.storage.Storage;
 import com.selfxdsd.core.mock.MockJsonResources;
@@ -270,41 +271,26 @@ public final class GitlabIssueTestCase {
     }
 
     /**
-     * An Issue should have an estimation of 60 minutes.
+     * A GitlabIssue can return its Estimation.
      */
     @Test
-    public void returnsIssueEstimation() {
-        final int estimation = new GitlabIssue(
-            URI.create("https://gitlab.com/api/v4/projects"
-                + "/john%2Ftest/issues/1"),
+    public void returnsEstimation() {
+        final Estimation estimation = new GithubIssue(
+            URI.create("http://localhost/issues/1"),
             Json.createObjectBuilder()
-                .add("iid", 1)
-                .add("web_url", "http://gitlab.com/john/"
-                    + "test/-/issues/1")
+                .add("number", 1)
+                .add("html_url", "http://localhost/issues/1")
                 .build(),
             Mockito.mock(Storage.class),
             Mockito.mock(JsonResources.class)
         ).estimation();
-        MatcherAssert.assertThat(estimation, Matchers.is(60));
-    }
-
-    /**
-     * A Pull Request should have an estimation of 30 minutes.
-     */
-    @Test
-    public void returnsPullRequestEstimation() {
-        final int estimation = new GitlabIssue(
-            URI.create("https://gitlab.com/api/v4/projects"
-                + "/john%2Ftest/merge_requests/1"),
-            Json.createObjectBuilder()
-                .add("iid", 1)
-                .add("web_url", "http://gitlab.com/john/"
-                    + "test/-/merge_requests/1")
-                .build(),
-            Mockito.mock(Storage.class),
-            Mockito.mock(JsonResources.class)
-        ).estimation();
-        MatcherAssert.assertThat(estimation, Matchers.is(30));
+        MatcherAssert.assertThat(
+            estimation,
+            Matchers.allOf(
+                Matchers.notNullValue(),
+                Matchers.instanceOf(LabelsEstimation.class)
+            )
+        );
     }
 
     /**

--- a/self-core-impl/src/test/java/com/selfxdsd/core/LabelsEstimationTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/LabelsEstimationTestCase.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Estimation;
+import com.selfxdsd.api.Issue;
+import com.selfxdsd.api.Label;
+import com.selfxdsd.api.Labels;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Unit tests for {@link LabelsEstimation}.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.39
+ */
+public final class LabelsEstimationTestCase {
+
+    /**
+     * Returns the default Issue estimation when there are no
+     * estimation labels.
+     */
+    @Test
+    public void returnsDefaultIssueEstimation() {
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.isPullRequest()).thenReturn(Boolean.FALSE);
+        final Labels labels = Mockito.mock(Labels.class);
+        Mockito.when(labels.iterator())
+            .thenReturn(new ArrayList<Label>().iterator());
+        Mockito.when(issue.labels()).thenReturn(labels);
+
+        final Estimation est = new LabelsEstimation(issue);
+
+        MatcherAssert.assertThat(
+            est.minutes(),
+            Matchers.equalTo(60)
+        );
+    }
+
+    /**
+     * Returns the default PR estimation when there are no
+     * estimation labels.
+     */
+    @Test
+    public void returnsDefaultPrEstimation() {
+        final Issue pull = Mockito.mock(Issue.class);
+        Mockito.when(pull.isPullRequest()).thenReturn(Boolean.TRUE);
+        final Labels labels = Mockito.mock(Labels.class);
+        Mockito.when(labels.iterator())
+            .thenReturn(new ArrayList<Label>().iterator());
+        Mockito.when(pull.labels()).thenReturn(labels);
+
+        final Estimation est = new LabelsEstimation(pull);
+
+        MatcherAssert.assertThat(
+            est.minutes(),
+            Matchers.equalTo(30)
+        );
+    }
+
+    /**
+     * Returns a label estimation with a single digit.
+     */
+    @Test
+    public void returnsSingleDigitLabelEstimation() {
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.isPullRequest()).thenReturn(Boolean.TRUE);
+        final Label label = Mockito.mock(Label.class);
+        Mockito.when(label.name()).thenReturn("8 minutes");
+        final Labels labels = Mockito.mock(Labels.class);
+        Mockito.when(labels.iterator()).thenReturn(List.of(label).iterator());
+        Mockito.when(issue.labels()).thenReturn(labels);
+
+        final Estimation est = new LabelsEstimation(issue);
+
+        MatcherAssert.assertThat(
+            est.minutes(),
+            Matchers.equalTo(8)
+        );
+    }
+
+    /**
+     * Returns a label estimation.
+     */
+    @Test
+    public void returnsLabelEstimation() {
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.isPullRequest()).thenReturn(Boolean.TRUE);
+        final Label label = Mockito.mock(Label.class);
+        Mockito.when(label.name()).thenReturn("45 min");
+        final Labels labels = Mockito.mock(Labels.class);
+        Mockito.when(labels.iterator()).thenReturn(List.of(label).iterator());
+        Mockito.when(issue.labels()).thenReturn(labels);
+
+        final Estimation est = new LabelsEstimation(issue);
+
+        MatcherAssert.assertThat(
+            est.minutes(),
+            Matchers.equalTo(45)
+        );
+    }
+
+    /**
+     * Returns a label estimation which has no spaces.
+     */
+    @Test
+    public void returnsLabelEstimationNoSpace() {
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.isPullRequest()).thenReturn(Boolean.TRUE);
+        final Label label = Mockito.mock(Label.class);
+        Mockito.when(label.name()).thenReturn("120m");
+        final Labels labels = Mockito.mock(Labels.class);
+        Mockito.when(labels.iterator()).thenReturn(List.of(label).iterator());
+        Mockito.when(issue.labels()).thenReturn(labels);
+
+        final Estimation est = new LabelsEstimation(issue);
+
+        MatcherAssert.assertThat(
+            est.minutes(),
+            Matchers.equalTo(120)
+        );
+    }
+
+    /**
+     * Returns a label estimation which is uppercase.
+     */
+    @Test
+    public void returnsLabelEstimationCaseInsensitive() {
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.isPullRequest()).thenReturn(Boolean.TRUE);
+        final Label label = Mockito.mock(Label.class);
+        Mockito.when(label.name()).thenReturn("125 MINUTES");
+        final Labels labels = Mockito.mock(Labels.class);
+        Mockito.when(labels.iterator()).thenReturn(List.of(label).iterator());
+        Mockito.when(issue.labels()).thenReturn(labels);
+
+        final Estimation est = new LabelsEstimation(issue);
+
+        MatcherAssert.assertThat(
+            est.minutes(),
+            Matchers.equalTo(125)
+        );
+    }
+}

--- a/self-core-impl/src/test/java/com/selfxdsd/core/LabelsEstimationTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/LabelsEstimationTestCase.java
@@ -85,14 +85,14 @@ public final class LabelsEstimationTestCase {
     }
 
     /**
-     * Returns a label estimation with a single digit.
+     * Minimum estimation should be 15 minutes.
      */
     @Test
-    public void returnsSingleDigitLabelEstimation() {
+    public void doesNotGoBellowMinimumEstimation() {
         final Issue issue = Mockito.mock(Issue.class);
         Mockito.when(issue.isPullRequest()).thenReturn(Boolean.TRUE);
         final Label label = Mockito.mock(Label.class);
-        Mockito.when(label.name()).thenReturn("8 minutes");
+        Mockito.when(label.name()).thenReturn("7 minutes");
         final Labels labels = Mockito.mock(Labels.class);
         Mockito.when(labels.iterator()).thenReturn(List.of(label).iterator());
         Mockito.when(issue.labels()).thenReturn(labels);
@@ -101,7 +101,7 @@ public final class LabelsEstimationTestCase {
 
         MatcherAssert.assertThat(
             est.minutes(),
-            Matchers.equalTo(8)
+            Matchers.equalTo(15)
         );
     }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/LabelsEstimationTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/LabelsEstimationTestCase.java
@@ -167,4 +167,25 @@ public final class LabelsEstimationTestCase {
             Matchers.equalTo(125)
         );
     }
+
+    /**
+     * Maximum estimation (360min) is not exceeded.
+     */
+    @Test
+    public void doesNotExceedMaximum() {
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.isPullRequest()).thenReturn(Boolean.TRUE);
+        final Label label = Mockito.mock(Label.class);
+        Mockito.when(label.name()).thenReturn("800 min");
+        final Labels labels = Mockito.mock(Labels.class);
+        Mockito.when(labels.iterator()).thenReturn(List.of(label).iterator());
+        Mockito.when(issue.labels()).thenReturn(labels);
+
+        final Estimation est = new LabelsEstimation(issue);
+
+        MatcherAssert.assertThat(
+            est.minutes(),
+            Matchers.equalTo(360)
+        );
+    }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/WithContributorLabelTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/WithContributorLabelTestCase.java
@@ -22,10 +22,7 @@
  */
 package com.selfxdsd.core;
 
-import com.selfxdsd.api.Comments;
-import com.selfxdsd.api.Issue;
-import com.selfxdsd.api.Provider;
-import com.selfxdsd.api.Labels;
+import com.selfxdsd.api.*;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -286,12 +283,13 @@ public final class WithContributorLabelTestCase {
      */
     @Test
     public void delegatesEstimation() {
+        final Estimation estimation = Mockito.mock(Estimation.class);
         final Issue decorated = Mockito.mock(Issue.class);
-        Mockito.when(decorated.estimation()).thenReturn(45);
+        Mockito.when(decorated.estimation()).thenReturn(estimation);
         final Issue withLabel = new WithContributorLabel(decorated);
         MatcherAssert.assertThat(
             withLabel.estimation(),
-            Matchers.is(45)
+            Matchers.is(estimation)
         );
         Mockito.verify(decorated, Mockito.times(1)).estimation();
     }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/DeregisterTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/DeregisterTestCase.java
@@ -193,6 +193,9 @@ public final class DeregisterTestCase {
         Mockito.when(issue.provider()).thenReturn(provider);
         Mockito.when(issue.role()).thenReturn(role);
         Mockito.when(issue.comments()).thenReturn(Mockito.mock(Comments.class));
+        final Estimation estimation = Mockito.mock(Estimation.class);
+        Mockito.when(estimation.minutes()).thenReturn(60);
+        Mockito.when(issue.estimation()).thenReturn(estimation);
         return issue;
     }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/RemoveTaskTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/RemoveTaskTestCase.java
@@ -134,6 +134,9 @@ public final class RemoveTaskTestCase {
         Mockito.when(issue.provider()).thenReturn(provider);
         Mockito.when(issue.role()).thenReturn(role);
         Mockito.when(issue.comments()).thenReturn(Mockito.mock(Comments.class));
+        final Estimation estimation = Mockito.mock(Estimation.class);
+        Mockito.when(estimation.minutes()).thenReturn(60);
+        Mockito.when(issue.estimation()).thenReturn(estimation);
         return issue;
     }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasks.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasks.java
@@ -92,7 +92,7 @@ public final class InMemoryTasks implements Tasks {
                 project,
                 issue.issueId(),
                 issue.role(),
-                issue.estimation(),
+                issue.estimation().minutes(),
                 this.storage
             );
             this.tasks.put(

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasksTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryTasksTestCase.java
@@ -273,6 +273,9 @@ public final class InMemoryTasksTestCase {
         Mockito.when(issue.repoFullName()).thenReturn(repoFullName);
         Mockito.when(issue.provider()).thenReturn(provider);
         Mockito.when(issue.role()).thenReturn(role);
+        final Estimation estimation = Mockito.mock(Estimation.class);
+        Mockito.when(estimation.minutes()).thenReturn(60);
+        Mockito.when(issue.estimation()).thenReturn(estimation);
         return issue;
     }
 


### PR DESCRIPTION
Fixes #736 

- Issue.estimation() returns Estimation
- Estimation is read from Labels (e.g. ``45 min``)
- Default Estimation is 60min for Issues and 30min for PRs
- Min Estimation is 15min, Max estimation is 360min
- Wrote unit tests and adapted existing unit tests.