### PR TITLE
#738 register repo labels before opening Issue

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssues.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssues.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Issue;
 import com.selfxdsd.api.Issues;
+import com.selfxdsd.api.Repo;
 import com.selfxdsd.api.storage.Storage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,6 +63,11 @@ final class GithubIssues implements Issues {
     private final JsonResources resources;
 
     /**
+     * Parent Repo.
+     */
+    private final Repo repo;
+
+    /**
      * Self storage, in case we want to store something.
      */
     private final Storage storage;
@@ -71,15 +77,18 @@ final class GithubIssues implements Issues {
      *
      * @param resources Github's JSON Resources.
      * @param issuesUri Issues base URI.
+     * @param repo Parent Repo.
      * @param storage Storage.
      */
     GithubIssues(
         final JsonResources resources,
         final URI issuesUri,
+        final Repo repo,
         final Storage storage
     ) {
         this.resources = resources;
         this.issuesUri = issuesUri;
+        this.repo = repo;
         this.storage = storage;
     }
 
@@ -138,6 +147,7 @@ final class GithubIssues implements Issues {
         final String body,
         final String... labels
     ) {
+        this.repo.labels().add(labels);
         final JsonArrayBuilder labelsArray = Json.createArrayBuilder();
         for(final String label : labels) {
             labelsArray.add(label);

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepo.java
@@ -104,6 +104,7 @@ final class GithubRepo extends BaseRepo {
         return new GithubIssues(
             this.resources(),
             URI.create(this.repoUri().toString() + "/issues"),
+            this,
             this.storage()
         );
     }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssuesITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssuesITCase.java
@@ -2,6 +2,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Issue;
 import com.selfxdsd.api.Issues;
+import com.selfxdsd.api.Repo;
 import com.selfxdsd.api.storage.Storage;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -33,7 +34,10 @@ public final class GithubIssuesITCase {
         final URI uri = URI.create(
             "https://api.github.com/repos/amihaiemil/docker-java-api/issues");
         final Issues issues = new GithubIssues(
-            new JsonResources.JdkHttp(), uri, mock(Storage.class)
+            new JsonResources.JdkHttp(),
+            uri,
+            mock(Repo.class),
+            mock(Storage.class)
         );
         final Issue issue = issues.getById("346");
         final JsonObject jsonIssue = issue.json();
@@ -74,7 +78,10 @@ public final class GithubIssuesITCase {
         final URI uri = URI.create(
             "https://api.github.com/repos/amihaiemil/docker-java-api/issues");
         final Issues issues = new GithubIssues(
-            new JsonResources.JdkHttp(), uri, mock(Storage.class)
+            new JsonResources.JdkHttp(),
+            uri,
+            mock(Repo.class),
+            mock(Storage.class)
         );
         final Issue issue = issues.getById("100000");
         assertThat(issue, nullValue());


### PR DESCRIPTION
Fixes #738 

Before opening an Issue with some labels, we register these labels in the Repo first (in order to give them a color).