### PR TITLE
#740 specify inviter tag on HelloIssue

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Invitation.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Invitation.java
@@ -39,6 +39,12 @@ public interface Invitation {
     JsonObject json();
 
     /**
+     * Login of the inviter.
+     * @return String.
+     */
+    String inviter();
+
+    /**
      * Repo where the invitation occured.
      * @return Repo.
      */

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubInvitation.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubInvitation.java
@@ -93,6 +93,11 @@ final class GithubInvitation implements Invitation {
     }
 
     @Override
+    public String inviter() {
+        return this.json.getJsonObject("inviter").getString("login");
+    }
+
+    @Override
     public Repo repo() {
         final String repoFullName = this.json
             .getJsonObject("repository")

--- a/self-core-impl/src/main/java/com/selfxdsd/core/HelloIssue.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/HelloIssue.java
@@ -66,6 +66,11 @@ final class HelloIssue implements Invitation {
     }
 
     @Override
+    public String inviter() {
+        return this.origin.inviter();
+    }
+
+    @Override
     public Repo repo() {
         return this.origin.repo();
     }
@@ -80,7 +85,7 @@ final class HelloIssue implements Invitation {
                 "Hello from Self XDSD!",
                 String.format(
                     this.helloMessage(),
-                    repo.owner().username()
+                    this.inviter()
                 ),
                 "no-task"
             );

--- a/self-core-impl/src/main/java/com/selfxdsd/core/StarRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/StarRepo.java
@@ -63,6 +63,11 @@ final class StarRepo implements Invitation {
     }
 
     @Override
+    public String inviter() {
+        return this.origin.inviter();
+    }
+
+    @Override
     public Repo repo() {
         return this.origin.repo();
     }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubInvitationTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubInvitationTestCase.java
@@ -61,6 +61,31 @@ public final class GithubInvitationTestCase {
     }
 
     /**
+     * A GithubInvitation can return the inviter.
+     */
+    @Test
+    public void returnsInviter() {
+        final JsonObject json = Json.createObjectBuilder()
+            .add("id", 1)
+            .add(
+                "inviter",
+                Json.createObjectBuilder()
+                    .add("login", "mihai")
+            ).build();
+        final Invitation invitation = new GithubInvitation(
+            Mockito.mock(JsonResources.class),
+            URI.create("https://api.github.com/repos/john/test/invitations"),
+            json,
+            new Github(Mockito.mock(User.class), Mockito.mock(Storage.class))
+        );
+        MatcherAssert.assertThat(
+            invitation.inviter(),
+            Matchers.equalTo("mihai")
+        );
+    }
+
+
+    /**
      * A GithubInvitation can return its Repo.
      */
     @Test

--- a/self-core-impl/src/test/java/com/selfxdsd/core/HelloIssueTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/HelloIssueTestCase.java
@@ -57,6 +57,21 @@ public final class HelloIssueTestCase {
     }
 
     /**
+     * HelloIssue delegates inviter() to the original Invitation.
+     */
+    @Test
+    public void delegatesInviter() {
+        final Invitation origin = Mockito.mock(Invitation.class);
+        Mockito.when(origin.inviter()).thenReturn("mihai");
+        final Invitation helloIssue = new HelloIssue(origin);
+        MatcherAssert.assertThat(
+            helloIssue.inviter(),
+            Matchers.is("mihai")
+        );
+        Mockito.verify(origin, Mockito.times(1)).inviter();
+    }
+
+    /**
      * HelloIssue delegates repo() to the original Invitation.
      */
     @Test
@@ -105,13 +120,11 @@ public final class HelloIssueTestCase {
     @Test
     public void acceptsAndOpensIssue() {
         final Repo repo = Mockito.mock(Repo.class);
-        final User owner = Mockito.mock(User.class);
-        Mockito.when(owner.username()).thenReturn("mihai");
-        Mockito.when(repo.owner()).thenReturn(owner);
         final Issues issues = Mockito.mock(Issues.class);
         Mockito.when(repo.issues()).thenReturn(issues);
         final Invitation origin = Mockito.mock(Invitation.class);
         Mockito.when(origin.repo()).thenReturn(repo);
+        Mockito.when(origin.inviter()).thenReturn("emil");
         final HelloIssue helloIssue = new HelloIssue(origin);
 
         helloIssue.accept();
@@ -124,7 +137,7 @@ public final class HelloIssueTestCase {
                 "Hello from Self XDSD!",
                 String.format(
                     helloIssue.helloMessage(),
-                    "mihai"
+                    "emil"
                 ),
                 "no-task"
             );

--- a/self-core-impl/src/test/java/com/selfxdsd/core/StarRepoTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/StarRepoTestCase.java
@@ -58,6 +58,21 @@ public final class StarRepoTestCase {
     }
 
     /**
+     * StarRepo delegates inviter() to the original Invitation.
+     */
+    @Test
+    public void delegatesInviter() {
+        final Invitation origin = Mockito.mock(Invitation.class);
+        Mockito.when(origin.inviter()).thenReturn("mihai");
+        final Invitation star = new StarRepo(origin);
+        MatcherAssert.assertThat(
+            star.inviter(),
+            Matchers.is("mihai")
+        );
+        Mockito.verify(origin, Mockito.times(1)).inviter();
+    }
+
+    /**
      * StarRepo delegates repo() to the original Invitation.
      */
     @Test


### PR DESCRIPTION
Fixes #740 

When opening the introductory issue, address it to the inviter.
Problem with ``this.repo.owner()`` was that the Github instance in use belongs to the PM, so ``owner()`` returns the PM.