### PR TITLE
#303 GitLab Invitations implemented and tested

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/Gitlab.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/Gitlab.java
@@ -33,8 +33,6 @@ import java.net.URI;
  * @version $Id$
  * @since 0.0.1
  * @todo #27:30min Continue adding integration tests for Gitlab provider.
- * @todo #300:30min Gitlab Invitations: implement and test invitations for
- *  Gitlab provider.
  */
 public final class Gitlab implements Provider {
 
@@ -122,7 +120,7 @@ public final class Gitlab implements Provider {
 
     @Override
     public Invitations invitations() {
-        throw new UnsupportedOperationException("Not yet implemented.");
+        return new GitlabRepoInvitations();
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborators.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborators.java
@@ -15,7 +15,7 @@ import java.net.URI;
  * @version $Id$
  * @since 0.0.13
  */
-public final class GitlabCollaborators implements Collaborators {
+final class GitlabCollaborators implements Collaborators {
 
     /**
      * Logger.

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepoInvitations.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepoInvitations.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Invitation;
+import com.selfxdsd.api.Invitations;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+/**
+ * Invitations to a Gitlab Repo.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.41
+ */
+final class GitlabRepoInvitations implements Invitations {
+
+    /**
+     * In the case of Gitlab, we use the 'Add Member' endpoint
+     * to invite the PM to the repo. This endpoint adds the PM
+     * to the project directly, so there are no invitations
+     * to accept, ever. See method GitlabCollaborators.invite(...).
+     * @return Always empty iterable.
+     */
+    @Override
+    public Iterator<Invitation> iterator() {
+        return new ArrayList<Invitation>().iterator();
+    }
+}

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabRepoInvitationsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabRepoInvitationsTestCase.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2020, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link GitlabRepoInvitations}.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.41
+ */
+public final class GitlabRepoInvitationsTestCase {
+
+    /**
+     * GitlabRepoInvitations should be an empty iterable.
+     */
+    @Test
+    public void isEmptyIterable() {
+        MatcherAssert.assertThat(
+            new GitlabRepoInvitations(),
+            Matchers.emptyIterable()
+        );
+    }
+
+}


### PR DESCRIPTION
PR for #303 

Implemented an empty GitlabRepoInvitations, because in the case of Gitlab there are no invitations to accept ever (when we invite the PM, they are automatically added as a Member).