### PR TITLE
#751 Contract.revenue and Invoice.amount implemented + tested

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Contract.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Contract.java
@@ -87,6 +87,14 @@ public interface Contract {
     BigDecimal value();
 
     /**
+     * Revenue. This is the total potential earnings of the Contributor.
+     * It's the sum of the active tasks' value and the value of the active
+     * Invoice (it's the Contract's value without the PM's commission).
+     * @return Revenue.
+     */
+    BigDecimal revenue();
+
+    /**
      * Time when this Contract has been marked from removal.<br><br>
      * If the contract is marked for removal, no more tasks will be assigned
      * to it and it will be removed after a certain period of time.

--- a/self-api/src/main/java/com/selfxdsd/api/Invoice.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Invoice.java
@@ -64,6 +64,12 @@ public interface Invoice {
     BigDecimal totalAmount();
 
     /**
+     * The value of the invoiced tasks, without the PM's commission.
+     * @return BigDecimal.
+     */
+    BigDecimal amount();
+
+    /**
      * Value of the commission.
      * @return BigDecimal.
      */

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contracts/StoredContract.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contracts/StoredContract.java
@@ -219,6 +219,16 @@ public final class StoredContract implements Contract {
     }
 
     @Override
+    public BigDecimal revenue() {
+        BigDecimal revenue = BigDecimal.valueOf(0);
+        for(final Task task : this.tasks()) {
+            revenue = revenue.add(task.value());
+        }
+        revenue = revenue.add(this.invoices().active().amount());
+        return revenue;
+    }
+
+    @Override
     public LocalDateTime markedForRemoval() {
         return this.markedForRemoval;
     }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/StoredInvoice.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/StoredInvoice.java
@@ -140,6 +140,15 @@ public final class StoredInvoice implements Invoice {
     }
 
     @Override
+    public BigDecimal amount() {
+        BigDecimal revenue = BigDecimal.valueOf(0);
+        for(final InvoicedTask task : this.tasks()) {
+            revenue = revenue.add(task.value());
+        }
+        return revenue;
+    }
+
+    @Override
     public BigDecimal commission() {
         BigDecimal commission = BigDecimal.valueOf(0);
         for(final InvoicedTask task : this.tasks()) {

--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/StoredTask.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/StoredTask.java
@@ -320,6 +320,11 @@ public final class StoredTask implements Task {
         }
 
         @Override
+        public BigDecimal revenue() {
+            return BigDecimal.valueOf(0);
+        }
+
+        @Override
         public LocalDateTime markedForRemoval() {
             return null;
         }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contracts/StoredContractTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contracts/StoredContractTestCase.java
@@ -402,6 +402,84 @@ public final class StoredContractTestCase {
     }
 
     /**
+     * StoredContract can return its revenue, which is
+     * the sum of the active Tasks, plus the revenue
+     * of the active invoice.
+     * Task.
+     *
+     * @checkstyle ExecutableStatementCount (50 lines)
+     */
+    @Test
+    public void returnsRevenue() {
+        final Task one = Mockito.mock(Task.class);
+        Mockito.when(one.value()).thenReturn(BigDecimal.valueOf(10000));
+        final Task two = Mockito.mock(Task.class);
+        Mockito.when(two.value()).thenReturn(BigDecimal.valueOf(15000));
+        final Task three = Mockito.mock(Task.class);
+        Mockito.when(three.value()).thenReturn(BigDecimal.valueOf(7500));
+        final Tasks tasks = Mockito.mock(Tasks.class);
+        Mockito.when(tasks.iterator()).thenReturn(
+            List.of(one, two, three).iterator()
+        );
+        final Invoices invoices = Mockito.mock(Invoices.class);
+        final Invoice active = Mockito.mock(Invoice.class);
+        Mockito.when(active.amount())
+            .thenReturn(BigDecimal.valueOf(10000));
+        Mockito.when(invoices.active()).thenReturn(active);
+
+        final Tasks allTasks = Mockito.mock(Tasks.class);
+        Mockito.when(
+            allTasks.ofContract(
+                new Contract.Id(
+                    "john/test",
+                    "mihai",
+                    "github",
+                    "DEV"
+                )
+            )
+        ).thenReturn(tasks);
+        final Invoices allInvoices = Mockito.mock(Invoices.class);
+        Mockito.when(
+            allInvoices.ofContract(
+                new Contract.Id(
+                    "john/test",
+                    "mihai",
+                    "github",
+                    "DEV"
+                )
+            )
+        ).thenReturn(invoices);
+
+        final Projects allProjects = Mockito.mock(Projects.class);
+        final Project project = Mockito.mock(Project.class);
+        Mockito.when(
+            allProjects.getProjectById("john/test", "github")
+        ).thenReturn(project);
+
+        final Storage storage = Mockito.mock(Storage.class);
+        Mockito.when(storage.projects()).thenReturn(allProjects);
+        Mockito.when(storage.tasks()).thenReturn(allTasks);
+        Mockito.when(storage.invoices()).thenReturn(allInvoices);
+
+        final Contract contract = new StoredContract(
+            new Contract.Id(
+                "john/test",
+                "mihai",
+                "github",
+                "DEV"
+            ),
+            BigDecimal.valueOf(15000),
+            LocalDateTime.now(),
+            storage
+        );
+
+        MatcherAssert.assertThat(
+            contract.revenue(),
+            Matchers.equalTo(BigDecimal.valueOf(42500))
+        );
+    }
+
+    /**
      * Can compare two StoredContract objects.
      */
     @Test

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/StoredInvoiceTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/StoredInvoiceTestCase.java
@@ -133,6 +133,45 @@ public final class StoredInvoiceTestCase {
     }
 
     /**
+     * Invoice can return its amount.
+     */
+    @Test
+    public void returnsAmount() {
+        final Storage storage = Mockito.mock(Storage.class);
+        final Invoice invoice = new StoredInvoice(
+            1,
+            Mockito.mock(Contract.class),
+            LocalDateTime.now(),
+            LocalDateTime.now(),
+            "transactionID",
+            storage
+        );
+        final InvoicedTasks all = Mockito.mock(InvoicedTasks.class);
+        Mockito.when(all.ofInvoice(invoice)).thenReturn(
+            new InvoiceTasks(
+                invoice,
+                () -> {
+                    final InvoicedTask task = Mockito.mock(InvoicedTask.class);
+                    Mockito.when(task.value())
+                        .thenReturn(BigDecimal.valueOf(1000));
+                    final List<InvoicedTask> tasks = new ArrayList<>();
+                    tasks.add(task);
+                    tasks.add(task);
+                    tasks.add(task);
+                    return tasks.stream();
+                },
+                storage
+            )
+        );
+        Mockito.when(storage.invoicedTasks()).thenReturn(all);
+
+        MatcherAssert.assertThat(
+            invoice.amount(),
+            Matchers.equalTo(BigDecimal.valueOf(3000))
+        );
+    }
+
+    /**
      * Invoice can return its total commission.
      */
     @Test


### PR DESCRIPTION
Fixes #751 

Added and tested methods Contract.revenue() and Invoice.amount();
They both represent the Contributor's money from the Contract (tasks + active invoice) and from the Invoice, respectively.