### PR TITLE
#759 GithubWebhooks.remove() implemented and tested

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Webhook.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Webhook.java
@@ -33,6 +33,7 @@ public interface Webhook {
     /**
      * Id of the Webhook.
      * @return String Id.
+     * @checkstyle MethodName (5 lines)
      */
     String id();
 

--- a/self-api/src/main/java/com/selfxdsd/api/Webhook.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Webhook.java
@@ -23,24 +23,23 @@
 package com.selfxdsd.api;
 
 /**
- * Repo webhooks.
+ * A Webhook set in the Provider.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 0.0.13
+ * @since 0.0.42
  */
-public interface Webhooks extends Iterable<Webhook> {
+public interface Webhook {
 
     /**
-     * Add a webhook for the Self Project.
-     * @param project Project.
-     * @return True or false, whether the webhook setup
-     *  was successful or not.
+     * Id of the Webhook.
+     * @return String Id.
      */
-    boolean add(final Project project);
+    String id();
 
     /**
-     * Remove any Self XDSD-related webhooks.
-     * @return True or false.
+     * URL of the Webhook.
+     * @return String URL.
      */
-    boolean remove();
+    String url();
+
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabWebhooks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabWebhooks.java
@@ -23,6 +23,7 @@
 package com.selfxdsd.core;
 
 import com.selfxdsd.api.Project;
+import com.selfxdsd.api.Webhook;
 import com.selfxdsd.api.Webhooks;
 import com.selfxdsd.api.storage.Storage;
 import org.slf4j.Logger;
@@ -31,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import javax.json.Json;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.util.Iterator;
 
 /**
  * Gitlab repo webhooks.
@@ -116,6 +118,13 @@ final class GitlabWebhooks implements Webhooks {
 
     @Override
     public boolean remove() {
+        throw new UnsupportedOperationException(
+            "Not yet implemented."
+        );
+    }
+
+    @Override
+    public Iterator<Webhook> iterator() {
         throw new UnsupportedOperationException(
             "Not yet implemented."
         );

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StoredProject.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StoredProject.java
@@ -46,6 +46,11 @@ import java.util.Objects;
  *  It should decide what kind of event has occurred and delegate it
  *  further to the ProjectManager who will deal with it. We still need
  *  the Issue Assigned case and Comment Created case.
+ * @todo #759:30min Method deactivate() from this class has to take the
+ *  Repo as parameter. This is because StoredProject's encapsulated Repo
+ *  doesn't have any authentication in this scenario (we don't save the
+ *  User's access token in the DB). Therefore, the Repo method parameter
+ *  should be properly authenticated by the User beforehand.
  */
 public final class StoredProject implements Project {
 


### PR DESCRIPTION
PR for #759 

* Implemented and tested GithubWebhooks.iterator() which we use to iterate over hooks and find the ones containing ``//self-xdsd.``;
* Implemented and tested GithubWebhooks.remove() (using iterator to get the ids to be deleted);
* Added puzzle for Project.deactivate(Repo).