### PR TITLE
#787 add labels to repo first

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabIssueLabels.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabIssueLabels.java
@@ -46,11 +46,6 @@ import java.util.stream.Collectors;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.39
- * @todo #723:30min Similarly to how GithubIssueLabels.add(...) is implemented,
- *  we should modify the add(...) method here to first add the labels to the
- *  repository, so they are colored differently. At the moment, they will
- *  automatically be created by Gitlab at Repo level, but they will always be
- *  blue.
  */
 final class GitlabIssueLabels implements Labels {
 
@@ -94,9 +89,18 @@ final class GitlabIssueLabels implements Labels {
 
     @Override
     public boolean add(final String... names) {
+        final GitlabRepoLabels repoLabels = new GitlabRepoLabels(
+            URI.create(
+                this.uri.toString()
+                    .replaceAll("/issues/[0-9]+", "/labels")
+            ),
+            this.resources
+        );
+        repoLabels.add(names);
         final boolean added;
         final String labels = Arrays.stream(names)
             .collect(Collectors.joining(","));
+        System.out.println("Issue Labels: " + this.uri.toString());
         LOG.debug(
             "Adding labels [" + labels + "] to GitLab Issue ["
             + this.uri + "]..."

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabIssueLabelsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabIssueLabelsTestCase.java
@@ -70,14 +70,42 @@ public final class GitlabIssueLabelsTestCase {
             labels.add("blue", "red", "green"),
             Matchers.is(Boolean.TRUE)
         );
-        MockJsonResources.MockRequest request = resources.requests().first();
-        MatcherAssert.assertThat(request.getUri(), Matchers.equalTo(uri));
+        MockJsonResources.MockRequest addBlueLabel = resources.requests()
+            .atIndex(0);
         MatcherAssert.assertThat(
-            request.getMethod(), Matchers.equalTo("PUT")
+            addBlueLabel.getUri(),
+            Matchers.equalTo(
+                URI.create(
+                    "https://gitlab.com/api/v4/projects/"
+                    + "/amihaiemil%2Ftestrepo/labels"
+                )
+            )
         );
-        final JsonObject body = (JsonObject) request.getBody();
         MatcherAssert.assertThat(
-            body.getString("add_labels"),
+            addBlueLabel.getMethod(), Matchers.equalTo("POST")
+        );
+        final JsonObject body = (JsonObject) addBlueLabel.getBody();
+        MatcherAssert.assertThat(
+            body.getString("name"),
+            Matchers.equalTo("blue")
+        );
+        MatcherAssert.assertThat(
+            body.getString("color").length(),
+            Matchers.equalTo(7)
+        );
+
+        MockJsonResources.MockRequest addIssueLabels = resources.requests()
+            .atIndex(3);
+        MatcherAssert.assertThat(
+            addIssueLabels.getUri(), Matchers.equalTo(uri)
+        );
+        MatcherAssert.assertThat(
+            addIssueLabels.getMethod(), Matchers.equalTo("PUT")
+        );
+        final JsonObject bodyAddIssueLabel = (JsonObject) addIssueLabels
+            .getBody();
+        MatcherAssert.assertThat(
+            bodyAddIssueLabel.getString("add_labels"),
             Matchers.equalTo("blue,red,green")
         );
     }


### PR DESCRIPTION
PR for #787 

Before adding labels to an Issue, we add them to the Repo first, so we can specify their color.