### PR TITLE
#793 equalsIgnoreCase repoFullName, provider, username everywhere

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Contract.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Contract.java
@@ -265,10 +265,10 @@ public interface Contract {
             }
             final Id id = (Id) object;
             //@checkstyle LineLength (5 lines)
-            return this.repoFullName.equals(id.repoFullName)
-                && this.contributorUsername.equals(id.contributorUsername)
-                && this.provider.equals(id.provider)
-                && this.role.equals(id.role);
+            return this.repoFullName.equalsIgnoreCase(id.repoFullName)
+                && this.contributorUsername.equalsIgnoreCase(id.contributorUsername)
+                && this.provider.equalsIgnoreCase(id.provider)
+                && this.role.equalsIgnoreCase(id.role);
         }
 
         @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/StoredUser.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/StoredUser.java
@@ -100,7 +100,7 @@ public final class StoredUser implements User {
     @Override
     public Provider provider() {
         final Provider provider;
-        if(this.provider.equals(Provider.Names.GITHUB)) {
+        if(this.provider.equalsIgnoreCase(Provider.Names.GITHUB)) {
             provider = new Github(this, this.storage);
         } else {
             provider = new Gitlab(this, this.storage);
@@ -134,7 +134,7 @@ public final class StoredUser implements User {
             return false;
         }
         final User other = (User) obj;
-        return this.username.equals(other.username())
-            && this.provider.equals(other.provider().name());
+        return this.username.equalsIgnoreCase(other.username())
+            && this.provider.equalsIgnoreCase(other.provider().name());
     }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contracts/ContributorContracts.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contracts/ContributorContracts.java
@@ -87,8 +87,9 @@ public final class ContributorContracts implements Contracts {
             .filter(
                 contract -> {
                     final Project project = contract.project();
-                    return project.repoFullName().equals(repoFullName)
-                        && project.provider().equals(repoProvider);
+                    //LineLength (1 line)
+                    return project.repoFullName().equalsIgnoreCase(repoFullName)
+                        && project.provider().equalsIgnoreCase(repoProvider);
                 }
             );
         return new ProjectContracts(
@@ -197,8 +198,8 @@ public final class ContributorContracts implements Contracts {
         final String username,
         final String provider
     ) {
-        return this.contributor.username().equals(username)
-            && this.contributor.provider().equals(provider);
+        return this.contributor.username().equalsIgnoreCase(username)
+            && this.contributor.provider().equalsIgnoreCase(provider);
     }
 
     /**

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contracts/ProjectContracts.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contracts/ProjectContracts.java
@@ -91,8 +91,8 @@ public final class ProjectContracts implements Contracts {
         final String repoFullName,
         final String repoProvider
     ) {
-        if(this.repoFullName.equals(repoFullName)
-            && this.provider.equals(repoProvider)
+        if(this.repoFullName.equalsIgnoreCase(repoFullName)
+            && this.provider.equalsIgnoreCase(repoProvider)
         ) {
             return this;
         }
@@ -107,11 +107,11 @@ public final class ProjectContracts implements Contracts {
             .filter(contract -> contract
                 .contributor()
                 .username()
-                .equals(contributor.username())
+                .equalsIgnoreCase(contributor.username())
                 && contract
                 .contributor()
                 .provider()
-                .equals(contributor.provider()))
+                .equalsIgnoreCase(contributor.provider()))
             .collect(Collectors.toList());
         return new ContributorContracts(
             contributor, ofContributor::stream, this.storage
@@ -126,8 +126,8 @@ public final class ProjectContracts implements Contracts {
         final BigDecimal hourlyRate,
         final String role
     ) {
-        if(!this.repoFullName.equals(repoFullName)
-            || !this.provider.equals(provider)
+        if(!this.repoFullName.equalsIgnoreCase(repoFullName)
+            || !this.provider.equalsIgnoreCase(provider)
         ) {
             throw new ContractsException.OfProject.Add(this.repoFullName,
                 this.provider);
@@ -159,8 +159,8 @@ public final class ProjectContracts implements Contracts {
         final BigDecimal hourlyRate
     ) {
         final Contract.Id cid = contract.contractId();
-        if(!this.repoFullName.equals(cid.getRepoFullName())
-            || !this.provider.equals(cid.getProvider())
+        if(!this.repoFullName.equalsIgnoreCase(cid.getRepoFullName())
+            || !this.provider.equalsIgnoreCase(cid.getProvider())
         ) {
             throw new ContractsException.OfProject.Update(
                 this.repoFullName,
@@ -177,8 +177,8 @@ public final class ProjectContracts implements Contracts {
         final LocalDateTime time
     ) {
         final Contract.Id cid = contract.contractId();
-        if(!this.repoFullName.equals(cid.getRepoFullName())
-            || !this.provider.equals(cid.getProvider())
+        if(!this.repoFullName.equalsIgnoreCase(cid.getRepoFullName())
+            || !this.provider.equalsIgnoreCase(cid.getProvider())
         ) {
             throw new ContractsException.OfProject.Delete(
                 this.repoFullName,
@@ -199,8 +199,8 @@ public final class ProjectContracts implements Contracts {
     public void remove(final Contract contract) {
         final Contract.Id cid = contract.contractId();
         if (
-            !this.repoFullName.equals(cid.getRepoFullName())
-                || !this.provider.equals(cid.getProvider())
+            !this.repoFullName.equalsIgnoreCase(cid.getRepoFullName())
+                || !this.provider.equalsIgnoreCase(cid.getProvider())
         ) {
             throw new ContractsException.OfProject.Delete(
                 this.repoFullName,

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contributors/ProjectContributors.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contributors/ProjectContributors.java
@@ -120,7 +120,7 @@ public final class ProjectContributors extends BasePaged
         final String username,
         final String provider
     ) {
-        if(!provider.equals(this.provider)) {
+        if(!provider.equalsIgnoreCase(this.provider)) {
             throw new ContributorsException.OfProject
                 .Add(this.repoFullName, this.provider);
         }
@@ -146,8 +146,8 @@ public final class ProjectContributors extends BasePaged
         return this.contributors.get()
             .skip((page.getNumber() - 1) * page.getSize())
             .limit(page.getSize())
-            .filter(c -> c.username().equals(username)
-                && c.provider().equals(provider))
+            .filter(c -> c.username().equalsIgnoreCase(username)
+                && c.provider().equalsIgnoreCase(provider))
             .findFirst()
             .orElse(null);
     }
@@ -157,8 +157,8 @@ public final class ProjectContributors extends BasePaged
         final String repoFullName,
         final String repoProvider
     ) {
-        if(this.repoFullName.equals(repoFullName)
-            && this.provider.equals(repoProvider)) {
+        if(this.repoFullName.equalsIgnoreCase(repoFullName)
+            && this.provider.equalsIgnoreCase(repoProvider)) {
             return this;
         }
         throw new ContributorsException.OfProject
@@ -167,7 +167,7 @@ public final class ProjectContributors extends BasePaged
 
     @Override
     public Contributors ofProvider(final String provider) {
-        if(this.provider.equals(provider)) {
+        if(this.provider.equalsIgnoreCase(provider)) {
             return this;
         }
         throw new ContributorsException.OfProject
@@ -213,7 +213,7 @@ public final class ProjectContributors extends BasePaged
             .filter(
                 contributor -> {
                     if(task.assignee() != null) {
-                        return !contributor.username().equals(
+                        return !contributor.username().equalsIgnoreCase(
                             task.assignee().username()
                         );
                     }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contributors/ProviderContributors.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contributors/ProviderContributors.java
@@ -98,7 +98,7 @@ public final class ProviderContributors extends BasePaged
         final String username,
         final String provider
     ) {
-        if(!provider.equals(this.provider)) {
+        if(!provider.equalsIgnoreCase(this.provider)) {
             throw new ContributorsException.OfProvider.Add(this.provider);
         }
         return this.storage.contributors().register(username, provider);
@@ -113,8 +113,8 @@ public final class ProviderContributors extends BasePaged
         return this.contributors.get()
             .skip((page.getNumber() - 1) * page.getSize())
             .limit(page.getSize())
-            .filter(c -> c.username().equals(username)
-                && c.provider().equals(provider))
+            .filter(c -> c.username().equalsIgnoreCase(username)
+                && c.provider().equalsIgnoreCase(provider))
             .findFirst()
             .orElse(null);
     }
@@ -124,7 +124,7 @@ public final class ProviderContributors extends BasePaged
         final String repoFullName,
         final String repoProvider
     ) {
-        if(!this.provider.equals(repoProvider)) {
+        if(!this.provider.equalsIgnoreCase(repoProvider)) {
             throw new ContributorsException.OfProvider.List(this.provider);
         }
         final Project project = this.storage
@@ -144,7 +144,7 @@ public final class ProviderContributors extends BasePaged
 
     @Override
     public Contributors ofProvider(final String provider) {
-        if(!this.provider.equals(provider)) {
+        if(!this.provider.equalsIgnoreCase(provider)) {
             throw new ContributorsException.OfProvider.List(this.provider);
         }
         return this;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contributors/StoredContributor.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contributors/StoredContributor.java
@@ -208,7 +208,7 @@ public final class StoredContributor implements Contributor {
             return false;
         }
         final Contributor other = (Contributor) obj;
-        return this.username.equals(other.username())
-            && this.provider.equals(other.provider());
+        return this.username.equalsIgnoreCase(other.username())
+            && this.provider.equalsIgnoreCase(other.provider());
     }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/AuthorIsAssignee.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/AuthorIsAssignee.java
@@ -66,7 +66,7 @@ public final class AuthorIsAssignee extends PreconditionCheck {
         if(task == null || task.assignee() == null) {
             LOG.debug("There is no task or no assignee.");
             this.onFalse().perform(event);
-        } else if(task.assignee().username().equals(author)) {
+        } else if(task.assignee().username().equalsIgnoreCase(author)) {
             LOG.debug("Author is indeed the task assignee. Resigning...");
             this.onTrue().perform(event);
         } else {

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/StoredProjectManager.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/StoredProjectManager.java
@@ -178,7 +178,7 @@ public final class StoredProjectManager implements ProjectManager {
     @Override
     public Provider provider() {
         final Provider provider;
-        if (this.provider.equals(Provider.Names.GITHUB)) {
+        if (this.provider.equalsIgnoreCase(Provider.Names.GITHUB)) {
             provider = new Github(new PmUser(this), this.storage);
         } else {
             provider = new Gitlab(new PmUser(this), this.storage);

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/PmProjects.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/PmProjects.java
@@ -105,9 +105,9 @@ public final class PmProjects extends BasePaged implements Projects {
             .limit(page.getSize())
             .filter(p -> {
                 final User owner = p.owner();
-                return owner.username().equals(user.username())
+                return owner.username().equalsIgnoreCase(user.username())
                     && owner.provider().name()
-                    .equals(user.provider().name());
+                    .equalsIgnoreCase(user.provider().name());
             });
         return new UserProjects(user, owned);
     }
@@ -120,8 +120,8 @@ public final class PmProjects extends BasePaged implements Projects {
         return this.projects.get()
             .skip((page.getNumber() - 1) * page.getSize())
             .limit(page.getSize())
-            .filter(p -> p.repoFullName().equals(repoFullName)
-                && p.provider().equals(repoProvider))
+            .filter(p -> p.repoFullName().equalsIgnoreCase(repoFullName)
+                && p.provider().equalsIgnoreCase(repoProvider))
             .findFirst()
             .orElse(null);
     }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StoredProject.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StoredProject.java
@@ -239,9 +239,9 @@ public final class StoredProject implements Project {
             LOG.error("Problem while removing webhooks.");
         }
         final String user;
-        if(Provider.Names.GITHUB.equals(provider)) {
+        if(Provider.Names.GITHUB.equalsIgnoreCase(provider)) {
             user = this.projectManager.username();
-        } else if (Provider.Names.GITLAB.equals(provider)) {
+        } else if (Provider.Names.GITLAB.equalsIgnoreCase(provider)) {
             user = this.projectManager.userId();
         } else {
             throw new IllegalStateException(
@@ -338,7 +338,7 @@ public final class StoredProject implements Project {
             return false;
         }
         final Project other = (Project) obj;
-        return this.repoFullName.equals(other.repoFullName())
-            && this.provider().equals(other.provider());
+        return this.repoFullName.equalsIgnoreCase(other.repoFullName())
+            && this.provider().equalsIgnoreCase(other.provider());
     }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/UserProjects.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/UserProjects.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
+ * @checkstyle LineLength (200 lines)
  * @todo #59:30min Implement and test method register(...).
  *  It should register the repo with respect to the fact that
  *  this is a User's Projects, meaning the given Repo has to
@@ -102,8 +103,8 @@ public final class UserProjects extends BasePaged implements Projects {
 
     @Override
     public Projects ownedBy(final User usr) {
-        if(this.user.username().equals(usr.username())
-            && this.user.provider().name().equals(usr.provider().name())) {
+        if(this.user.username().equalsIgnoreCase(usr.username())
+            && this.user.provider().name().equalsIgnoreCase(usr.provider().name())) {
             return this;
         }
         throw new IllegalStateException(
@@ -121,8 +122,8 @@ public final class UserProjects extends BasePaged implements Projects {
             .get()
             .skip((page.getNumber() - 1) * page.getSize())
             .limit(page.getSize())
-            .filter(p -> p.repoFullName().equals(repoFullName)
-                && p.provider().equals(repoProvider))
+            .filter(p -> p.repoFullName().equalsIgnoreCase(repoFullName)
+                && p.provider().equalsIgnoreCase(repoProvider))
             .findFirst()
             .orElse(null);
     }
@@ -135,8 +136,8 @@ public final class UserProjects extends BasePaged implements Projects {
     @Override
     public void remove(final Project project) {
         final User owner = project.owner();
-        if(this.user.username().equals(owner.username())
-            && this.user.provider().name().equals(owner.provider().name())) {
+        if(this.user.username().equalsIgnoreCase(owner.username())
+            && this.user.provider().name().equalsIgnoreCase(owner.provider().name())) {
             project.deactivate(project.repo());
         } else {
             throw new IllegalStateException(

--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContractTasks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContractTasks.java
@@ -55,8 +55,8 @@ public final class ContractTasks implements Tasks {
                         final String provider) {
         return this.tasks.get()
             .filter(t -> t.issueId().equals(issueId)
-                && t.project().repoFullName().equals(repoFullName)
-                && t.project().provider().equals(provider))
+                && t.project().repoFullName().equalsIgnoreCase(repoFullName)
+                && t.project().provider().equalsIgnoreCase(provider))
             .findFirst()
             .orElse(null);
     }
@@ -70,8 +70,8 @@ public final class ContractTasks implements Tasks {
     @Override
     public Tasks ofProject(final String repoFullName,
                            final String repoProvider) {
-        if (this.contractId.getRepoFullName().equals(repoFullName)
-            && this.contractId.getProvider().equals(repoProvider)) {
+        if (this.contractId.getRepoFullName().equalsIgnoreCase(repoFullName)
+            && this.contractId.getProvider().equalsIgnoreCase(repoProvider)) {
             return this;
         } else {
             throw new TasksException.OfProject.List(
@@ -84,8 +84,8 @@ public final class ContractTasks implements Tasks {
     @Override
     public Tasks ofContributor(final String username,
                                final String provider) {
-        if (this.contractId.getContributorUsername().equals(username)
-            && this.contractId.getProvider().equals(provider)) {
+        if (this.contractId.getContributorUsername().equalsIgnoreCase(username)
+            && this.contractId.getProvider().equalsIgnoreCase(provider)) {
             return this;
         } else {
             throw new TasksException.OfContributor.List(

--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContributorTasks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ContributorTasks.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
  * @author criske
  * @version $Id$
  * @since 0.0.1
+ * @checkstyle LineLength (200 lines)
  */
 public final class ContributorTasks implements Tasks {
 
@@ -65,8 +66,8 @@ public final class ContributorTasks implements Tasks {
                         final String provider) {
         return this.tasks.get()
             .filter(t -> t.issueId().equals(issueId)
-                && t.project().repoFullName().equals(repoFullName)
-                && t.project().provider().equals(provider))
+                && t.project().repoFullName().equalsIgnoreCase(repoFullName)
+                && t.project().provider().equalsIgnoreCase(provider))
             .findFirst()
             .orElse(null);
     }
@@ -88,8 +89,8 @@ public final class ContributorTasks implements Tasks {
     @Override
     public Task unassign(final Task task) {
         final boolean isOfContributor = task.assignee() != null
-            && task.assignee().username().equals(this.username)
-            && task.assignee().provider().equals(this.provider);
+            && task.assignee().username().equalsIgnoreCase(this.username)
+            && task.assignee().provider().equalsIgnoreCase(this.provider);
         if (!isOfContributor) {
             throw new TasksException.OfContributor
                 .NotFound(this.username, this.provider);
@@ -101,8 +102,8 @@ public final class ContributorTasks implements Tasks {
     public Tasks ofProject(final String repoFullName,
                            final String repoProvider) {
         final Supplier<Stream<Task>> ofProject = () -> tasks.get()
-            .filter(t -> t.project().repoFullName().equals(repoFullName)
-                && t.project().provider().equals(provider));
+            .filter(t -> t.project().repoFullName().equalsIgnoreCase(repoFullName)
+                && t.project().provider().equalsIgnoreCase(provider));
         return new ProjectTasks(repoFullName, provider, ofProject, storage);
     }
 
@@ -111,8 +112,8 @@ public final class ContributorTasks implements Tasks {
         final String username,
         final String provider
     ) {
-        if (this.username.equals(username)
-            && this.provider.equals(provider)) {
+        if (this.username.equalsIgnoreCase(username)
+            && this.provider.equalsIgnoreCase(provider)) {
             return this;
         }
         throw new TasksException.OfContributor.List(username, provider);
@@ -123,8 +124,8 @@ public final class ContributorTasks implements Tasks {
         final Supplier<Stream<Task>> tasksOf = () -> this.tasks
             .get()
             .filter(
-                t -> t.project().repoFullName().equals(id.getRepoFullName())
-                    && t.project().provider().equals(id.getProvider())
+                t -> t.project().repoFullName().equalsIgnoreCase(id.getRepoFullName())
+                    && t.project().provider().equalsIgnoreCase(id.getProvider())
                     && t.assignee().username()
                     .endsWith(id.getContributorUsername())
                     && t.role().equals(id.getRole()));

--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ProjectTasks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/ProjectTasks.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
+ * @checkstyle LineLength (200 lines)
  */
 public final class ProjectTasks implements Tasks {
 
@@ -90,15 +91,15 @@ public final class ProjectTasks implements Tasks {
     ) {
         return this.tasks.get().filter(
             task -> task.issueId().equals(issueId)
-                && task.project().repoFullName().equals(repoFullName)
-                && task.project().provider().equals(provider)
+                && task.project().repoFullName().equalsIgnoreCase(repoFullName)
+                && task.project().provider().equalsIgnoreCase(provider)
         ).findFirst().orElse(null);
     }
 
     @Override
     public Task register(final Issue issue) {
-        if(!this.repoFullName.equals(issue.repoFullName())
-            || !this.provider.equals(issue.provider())) {
+        if(!this.repoFullName.equalsIgnoreCase(issue.repoFullName())
+            || !this.provider.equalsIgnoreCase(issue.provider())) {
             throw new TasksException.OfProject.Add(
                 this.repoFullName,
                 this.provider
@@ -120,8 +121,8 @@ public final class ProjectTasks implements Tasks {
     @Override
     public Task unassign(final Task task) {
         final boolean isOfProject = task.project().repoFullName()
-            .equals(this.repoFullName) && task.project().provider()
-            .equals(this.provider);
+            .equalsIgnoreCase(this.repoFullName) && task.project().provider()
+            .equalsIgnoreCase(this.provider);
         if (!isOfProject) {
             throw new TasksException.OfProject.NotFound(
                 this.repoFullName,
@@ -136,8 +137,8 @@ public final class ProjectTasks implements Tasks {
         final String repoFullName,
         final String repoProvider
     ) {
-        if(this.repoFullName.equals(repoFullName)
-            && this.provider.equals(repoProvider)) {
+        if(this.repoFullName.equalsIgnoreCase(repoFullName)
+            && this.provider.equalsIgnoreCase(repoProvider)) {
             return this;
         }
         throw new TasksException.OfProject.List(repoFullName, repoProvider);
@@ -148,8 +149,8 @@ public final class ProjectTasks implements Tasks {
         final Supplier<Stream<Task>> ofContributor = () -> tasks
             .get()
             .filter(t -> t.assignee() != null
-                && t.assignee().username().equals(username)
-                && t.assignee().provider().equals(provider));
+                && t.assignee().username().equalsIgnoreCase(username)
+                && t.assignee().provider().equalsIgnoreCase(provider));
         return new ContributorTasks(username, provider, ofContributor, storage);
     }
 
@@ -157,8 +158,8 @@ public final class ProjectTasks implements Tasks {
     public Tasks ofContract(final Contract.Id id) {
         final Supplier<Stream<Task>> tasksOf = () -> this.tasks
             .get()
-            .filter(t -> t.project().repoFullName().equals(id.getRepoFullName())
-                && t.project().provider().equals(id.getProvider())
+            .filter(t -> t.project().repoFullName().equalsIgnoreCase(id.getRepoFullName())
+                && t.project().provider().equalsIgnoreCase(id.getProvider())
                 && t.assignee().username().endsWith(id.getContributorUsername())
                 && t.role().equals(id.getRole()));
         return new ContractTasks(id, tasksOf, this.storage);
@@ -168,8 +169,8 @@ public final class ProjectTasks implements Tasks {
     public Tasks unassigned() {
         final Supplier<Stream<Task>> unassigned = () -> tasks.get()
             .filter(t -> t.assignee() == null
-                && t.project().repoFullName().equals(repoFullName)
-                && t.project().provider().equals(provider));
+                && t.project().repoFullName().equalsIgnoreCase(repoFullName)
+                && t.project().provider().equalsIgnoreCase(provider));
         return new UnassignedTasks(unassigned, storage);
     }
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/StoredResignation.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/StoredResignation.java
@@ -112,7 +112,7 @@ public final class StoredResignation implements Resignation {
         }
         final Resignation other = (Resignation) obj;
         return this.contributor.username()
-            .equals(other.contributor().username()) && this.task
+            .equalsIgnoreCase(other.contributor().username()) && this.task
             .equals(other.task());
     }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/StoredTask.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/StoredTask.java
@@ -36,6 +36,7 @@ import java.util.Objects;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
+ * @checkstyle LineLength (500 lines)
  */
 public final class StoredTask implements Task {
 
@@ -179,7 +180,7 @@ public final class StoredTask implements Task {
             );
         }
         final int deadlineDays;
-        if(Contract.Roles.REV.equals(this.role())) {
+        if(Contract.Roles.REV.equalsIgnoreCase(this.role())) {
             deadlineDays = 3;
         } else {
             deadlineDays = 10;
@@ -246,8 +247,8 @@ public final class StoredTask implements Task {
         final Task other = (Task) obj;
         final Project otherProject = other.project();
         return this.issueId.equals(other.issue().issueId())
-            && this.project().repoFullName().equals(otherProject.repoFullName())
-            && this.project().provider().equals(otherProject.provider());
+            && this.project().repoFullName().equalsIgnoreCase(otherProject.repoFullName())
+            && this.project().provider().equalsIgnoreCase(otherProject.provider());
     }
 
     /**

--- a/self-core-impl/src/main/java/com/selfxdsd/core/tasks/UnassignedTasks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/tasks/UnassignedTasks.java
@@ -49,8 +49,8 @@ public final class UnassignedTasks implements Tasks {
         return this.tasks
             .get()
             .filter(t -> t.issueId().equals(issueId)
-                && t.project().repoFullName().equals(repoFullName)
-                && t.project().provider().equals(provider))
+                && t.project().repoFullName().equalsIgnoreCase(repoFullName)
+                && t.project().provider().equalsIgnoreCase(provider))
             .findFirst()
             .orElse(null);
     }
@@ -80,8 +80,8 @@ public final class UnassignedTasks implements Tasks {
                            final String repoProvider) {
         final Supplier<Stream<Task>> ofProject = () -> tasks.get()
             .filter(t -> t.assignee() == null
-                && t.project().repoFullName().equals(repoFullName)
-                && t.project().provider().equals(repoProvider));
+                && t.project().repoFullName().equalsIgnoreCase(repoFullName)
+                && t.project().provider().equalsIgnoreCase(repoProvider));
         return new ProjectTasks(repoFullName, repoProvider, ofProject, storage);
     }
 


### PR DESCRIPTION
Fixes #793 

The problem was about equals comparison in Contract id, which should have been equalsIgnoreCase.
For safety reasons, we changed all the equals for username, repoFullName and provider to equalsIgnoreCase.