### PR TITLE
#797 remove Task should happen inside InvoicedTasks.register

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/StoredProjectManager.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/StoredProjectManager.java
@@ -474,7 +474,6 @@ public final class StoredProjectManager implements ProjectManager {
                                 assignee.username()
                             )
                         );
-                        this.storage.tasks().remove(task);
                         if(issue.assignee() != null) {
                             issue.unassign(issue.assignee());
                         }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
@@ -1332,7 +1332,6 @@ public final class StoredProjectManagerTestCase {
         Mockito.verify(active, Mockito.times(1))
             .register(task, BigDecimal.valueOf(80.0)
                 .setScale(2, RoundingMode.HALF_UP));
-        Mockito.verify(all, Mockito.times(1)).remove(task);
         Mockito.verify(comments, Mockito.times(1)).post(Mockito.anyString());
     }
 


### PR DESCRIPTION
Fixes #797 

Removed 

```java
this.storage.tasks().remove(task);
```
from StoredProjectManager.assignedTasks(...);

The task should be removed from the tasks table within the same DB transaction as InvoicedTasks.register.