### PR TITLE
#794 LabelEstimation ignored huge numbers + unit tests

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/LabelsEstimation.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/LabelsEstimation.java
@@ -47,7 +47,7 @@ final class LabelsEstimation implements Estimation {
      * Label regex.
      * @checkstyle LineLength (5 lines)
      */
-    private static final String ESTIMATION = "^([1-9]+[0-9]*)[ ]*(minutes|min|m)$";
+    private static final String ESTIMATION = "^([1-9][0-9]{0,5})[ ]*(minutes|min|m)$";
 
     /**
      * Maximum estimation allowed.

--- a/self-core-impl/src/test/java/com/selfxdsd/core/LabelsEstimationTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/LabelsEstimationTestCase.java
@@ -188,4 +188,90 @@ public final class LabelsEstimationTestCase {
             Matchers.equalTo(360)
         );
     }
+
+    /**
+     * Huge numbers are ignored and the default estimation is returned.
+     */
+    @Test
+    public void returnsDefaultOnHugeNumber() {
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.isPullRequest()).thenReturn(Boolean.TRUE);
+        final Label label = Mockito.mock(Label.class);
+        Mockito.when(label.name()).thenReturn(
+            "100000000000000000000000000000000 min"
+        );
+        final Labels labels = Mockito.mock(Labels.class);
+        Mockito.when(labels.iterator()).thenReturn(List.of(label).iterator());
+        Mockito.when(issue.labels()).thenReturn(labels);
+
+        final Estimation est = new LabelsEstimation(issue);
+
+        MatcherAssert.assertThat(
+            est.minutes(),
+            Matchers.equalTo(30)
+        );
+    }
+
+    /**
+     * Comma numbers are ignored and the default estimation is returned.
+     */
+    @Test
+    public void returnsDefaultOnCommaNumber() {
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.isPullRequest()).thenReturn(Boolean.TRUE);
+        final Label label = Mockito.mock(Label.class);
+        Mockito.when(label.name()).thenReturn("60.35 min");
+        final Labels labels = Mockito.mock(Labels.class);
+        Mockito.when(labels.iterator()).thenReturn(List.of(label).iterator());
+        Mockito.when(issue.labels()).thenReturn(labels);
+
+        final Estimation est = new LabelsEstimation(issue);
+
+        MatcherAssert.assertThat(
+            est.minutes(),
+            Matchers.equalTo(30)
+        );
+    }
+
+    /**
+     * Negative numbers are ignored and the default estimation is returned.
+     */
+    @Test
+    public void returnsDefaultOnNegativeNumber() {
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.isPullRequest()).thenReturn(Boolean.TRUE);
+        final Label label = Mockito.mock(Label.class);
+        Mockito.when(label.name()).thenReturn("-30 min");
+        final Labels labels = Mockito.mock(Labels.class);
+        Mockito.when(labels.iterator()).thenReturn(List.of(label).iterator());
+        Mockito.when(issue.labels()).thenReturn(labels);
+
+        final Estimation est = new LabelsEstimation(issue);
+
+        MatcherAssert.assertThat(
+            est.minutes(),
+            Matchers.equalTo(30)
+        );
+    }
+
+    /**
+     * Zero estimation is ignored and the default estimation is returned.
+     */
+    @Test
+    public void returnsDefaultOnZero() {
+        final Issue issue = Mockito.mock(Issue.class);
+        Mockito.when(issue.isPullRequest()).thenReturn(Boolean.TRUE);
+        final Label label = Mockito.mock(Label.class);
+        Mockito.when(label.name()).thenReturn("0 min");
+        final Labels labels = Mockito.mock(Labels.class);
+        Mockito.when(labels.iterator()).thenReturn(List.of(label).iterator());
+        Mockito.when(issue.labels()).thenReturn(labels);
+
+        final Estimation est = new LabelsEstimation(issue);
+
+        MatcherAssert.assertThat(
+            est.minutes(),
+            Matchers.equalTo(30)
+        );
+    }
 }


### PR DESCRIPTION
Fixes #794 

LabelEstimation regex modified to accept a number with max 6 digits.
Added unit tests.