### PR TITLE
#811 Implemented Invoice.billedBy and billedTo

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Invoice.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Invoice.java
@@ -10,10 +10,6 @@ import java.time.LocalDateTime;
  * @author criske
  * @version $Id$
  * @since 0.0.3
- * @todo #803:60min Add methods String::from() and String::to(). StoredInvoice
- *  should accept these values in the constructor. If these values are null,
- *  they should be read from Project.billingInfo and Contributor.billingInfo.
- *  The Project and the Contributor are accessible via the Contract.
  */
 public interface Invoice {
 

--- a/self-api/src/main/java/com/selfxdsd/api/Invoice.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Invoice.java
@@ -56,6 +56,18 @@ public interface Invoice {
     String transactionId();
 
     /**
+     * Who emitted the Invoice?
+     * @return String.
+     */
+    String billedBy();
+
+    /**
+     * For whom this invoice is for? (who should pay it).
+     * @return String.
+     */
+    String billedTo();
+
+    /**
      * Tasked invoiced here.
      * @return InvoicedTasks.
      */

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/StoredInvoice.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/StoredInvoice.java
@@ -39,6 +39,16 @@ public final class StoredInvoice implements Invoice {
     private final String transactionId;
 
     /**
+     * Who emitted this Invoice?
+     */
+    private final String billedBy;
+
+    /**
+     * To whom is this Invoice billed? Who pays?
+     */
+    private final String billedTo;
+
+    /**
      * Self storage context.
      */
     private final Storage storage;
@@ -50,6 +60,8 @@ public final class StoredInvoice implements Invoice {
      * @param createdAt Invoice creation time.
      * @param paymentTime Time when this Invoice has been paid.
      * @param transactionId The payment's transaction ID.
+     * @param billedBy Who emitted the Invoice.
+     * @param billedTo Who pays it.
      * @param storage Self storage context.
      */
     public StoredInvoice(
@@ -58,6 +70,8 @@ public final class StoredInvoice implements Invoice {
         final LocalDateTime createdAt,
         final LocalDateTime paymentTime,
         final String transactionId,
+        final String billedBy,
+        final String billedTo,
         final Storage storage
     ) {
         this.id = id;
@@ -65,6 +79,8 @@ public final class StoredInvoice implements Invoice {
         this.createdAt = createdAt;
         this.paymentTime = paymentTime;
         this.transactionId = transactionId;
+        this.billedBy = billedBy;
+        this.billedTo = billedTo;
         this.storage = storage;
     }
 
@@ -118,6 +134,16 @@ public final class StoredInvoice implements Invoice {
     @Override
     public String transactionId() {
         return this.transactionId;
+    }
+
+    @Override
+    public String billedBy() {
+        throw new UnsupportedOperationException("Not yet implemented.");
+    }
+
+    @Override
+    public String billedTo() {
+        throw new UnsupportedOperationException("Not yet implemented.");
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/StoredInvoice.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/StoredInvoice.java
@@ -138,12 +138,24 @@ public final class StoredInvoice implements Invoice {
 
     @Override
     public String billedBy() {
-        throw new UnsupportedOperationException("Not yet implemented.");
+        final String billedBy;
+        if(this.billedBy != null && !this.billedBy.isEmpty()) {
+            billedBy = this.billedBy;
+        } else {
+            billedBy = this.contract.contributor().billingInfo().toString();
+        }
+        return billedBy;
     }
 
     @Override
     public String billedTo() {
-        throw new UnsupportedOperationException("Not yet implemented.");
+        final String billedTo;
+        if(this.billedTo != null && !this.billedTo.isEmpty()) {
+            billedTo = this.billedTo;
+        } else {
+            billedTo = this.contract.project().billingInfo().toString();
+        }
+        return billedTo;
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
@@ -138,7 +138,9 @@ public final class FakeWallet implements Wallet {
                 invoice.contract(),
                 invoice.createdAt(),
                 LocalDateTime.now(),
-                UUID.randomUUID().toString().replace("-", ""),
+                "not_paid_" + UUID.randomUUID().toString().replace("-", ""),
+                null,
+                null,
                 this.storage
             ));
         if (!paid) {

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
@@ -128,21 +128,24 @@ public final class FakeWallet implements Wallet {
         }
         LOG.debug(
             "[FAKE] Paying Invoice #" + invoice.invoiceId()
-                + " of Contract " + invoice.contract().contractId()
-                + "..."
+            + " of Contract " + invoice.contract().contractId()
+            + "..."
         );
+        final String uuid = UUID.randomUUID().toString().replace("-", "");
         final boolean paid = this.storage
             .invoices()
-            .registerAsPaid(new StoredInvoice(
-                invoice.invoiceId(),
-                invoice.contract(),
-                invoice.createdAt(),
-                LocalDateTime.now(),
-                "not_paid_" + UUID.randomUUID().toString().replace("-", ""),
-                null,
-                null,
-                this.storage
-            ));
+            .registerAsPaid(
+                new StoredInvoice(
+                    invoice.invoiceId(),
+                    invoice.contract(),
+                    invoice.createdAt(),
+                    LocalDateTime.now(),
+                    "not_paid_" + uuid,
+                    invoice.billedBy(),
+                    invoice.billedTo(),
+                    this.storage
+                )
+            );
         if (!paid) {
             throw new WalletPaymentException(
                 "Could not pay invoice #" + invoice.invoiceId()

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
@@ -241,15 +241,17 @@ public final class StripeWallet implements Wallet {
                     .ofEpochSecond(paymentIntent.getCreated(),
                         0, OffsetDateTime.now().getOffset());
                 this.storage.invoices()
-                    .registerAsPaid(new StoredInvoice(
-                        invoice.invoiceId(),
-                        invoice.contract(),
-                        invoice.createdAt(),
-                        paymentDate,
-                        paymentIntent.getId(),
-                        null,
-                        null,
-                        this.storage)
+                    .registerAsPaid(
+                        new StoredInvoice(
+                            invoice.invoiceId(),
+                            invoice.contract(),
+                            invoice.createdAt(),
+                            paymentDate,
+                            paymentIntent.getId(),
+                            invoice.billedBy(),
+                            invoice.billedTo(),
+                            this.storage
+                        )
                     );
             } else {
                 LOG.error("[STRIPE] PaymentIntent status: " + status);

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
@@ -247,6 +247,8 @@ public final class StripeWallet implements Wallet {
                         invoice.createdAt(),
                         paymentDate,
                         paymentIntent.getId(),
+                        null,
+                        null,
                         this.storage)
                     );
             } else {

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/StoredInvoiceTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/StoredInvoiceTestCase.java
@@ -484,4 +484,107 @@ public final class StoredInvoiceTestCase {
             Matchers.equalTo(invoiceTwo.hashCode()));
     }
 
+    /**
+     * If the billedBy attribute is set in the constructor
+     * (not null and not empty), that's the value that should be
+     * returned.
+     */
+    @Test
+    public void returnsSetBilledBy() {
+        final Invoice invoice = new StoredInvoice(
+            1,
+            Mockito.mock(Contract.class),
+            LocalDateTime.now(),
+            LocalDateTime.now(),
+            "transacetionId123",
+            "mihai",
+            "vlad",
+            Mockito.mock(Storage.class)
+        );
+        MatcherAssert.assertThat(
+            invoice.billedBy(),
+            Matchers.equalTo("mihai")
+        );
+    }
+
+    /**
+     * If the billedTo attribute is set in the constructor
+     * (not null and not empty), that's the value that should be
+     * returned.
+     */
+    @Test
+    public void returnsSetBilledTo() {
+        final Invoice invoice = new StoredInvoice(
+            1,
+            Mockito.mock(Contract.class),
+            LocalDateTime.now(),
+            LocalDateTime.now(),
+            "transacetionId123",
+            "mihai",
+            "vlad",
+            Mockito.mock(Storage.class)
+        );
+        MatcherAssert.assertThat(
+            invoice.billedTo(),
+            Matchers.equalTo("vlad")
+        );
+    }
+
+    /**
+     * If the billedBy is not given as ctor parameter (set to null),
+     * then it should be read from the Contract.
+     */
+    @Test
+    public void returnsContractBilledBy() {
+        final BillingInfo info = Mockito.mock(BillingInfo.class);
+        Mockito.when(info.toString()).thenReturn("Contributor LLC");
+        final Contributor contributor = Mockito.mock(Contributor.class);
+        Mockito.when(contributor.billingInfo()).thenReturn(info);
+        final Contract contract = Mockito.mock(Contract.class);
+        Mockito.when(contract.contributor()).thenReturn(contributor);
+
+        final Invoice invoice = new StoredInvoice(
+            1,
+            contract,
+            LocalDateTime.now(),
+            LocalDateTime.now(),
+            "transacetionId123",
+            null,
+            "vlad",
+            Mockito.mock(Storage.class)
+        );
+        MatcherAssert.assertThat(
+            invoice.billedBy(),
+            Matchers.equalTo("Contributor LLC")
+        );
+    }
+
+    /**
+     * If the billedTo is not given as ctor parameter (set to null),
+     * then it should be read from the Contract.
+     */
+    @Test
+    public void returnsContractBilledTo() {
+        final BillingInfo info = Mockito.mock(BillingInfo.class);
+        Mockito.when(info.toString()).thenReturn("Project LLC");
+        final Project project = Mockito.mock(Project.class);
+        Mockito.when(project.billingInfo()).thenReturn(info);
+        final Contract contract = Mockito.mock(Contract.class);
+        Mockito.when(contract.project()).thenReturn(project);
+
+        final Invoice invoice = new StoredInvoice(
+            1,
+            contract,
+            LocalDateTime.now(),
+            LocalDateTime.now(),
+            "transacetionId123",
+            "mihai",
+            null,
+            Mockito.mock(Storage.class)
+        );
+        MatcherAssert.assertThat(
+            invoice.billedTo(),
+            Matchers.equalTo("Project LLC")
+        );
+    }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/StoredInvoiceTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/StoredInvoiceTestCase.java
@@ -35,6 +35,8 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            "mihai",
+            "vlad",
             Mockito.mock(Storage.class)
         );
         assertThat(invoice.invoiceId(), is(1));
@@ -52,6 +54,8 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            "mihai",
+            "vlad",
             Mockito.mock(Storage.class)
         );
         assertThat(invoice.contract(), is(contract));
@@ -69,6 +73,8 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transactionID",
+            "mihai",
+            "vlad",
             storage
         );
         final InvoicedTasks all = Mockito.mock(InvoicedTasks.class);
@@ -105,6 +111,8 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transactionID",
+            "mihai",
+            "vlad",
             storage
         );
         final InvoicedTasks all = Mockito.mock(InvoicedTasks.class);
@@ -144,6 +152,8 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transactionID",
+            "mihai",
+            "vlad",
             storage
         );
         final InvoicedTasks all = Mockito.mock(InvoicedTasks.class);
@@ -183,6 +193,8 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transactionID",
+            "mihai",
+            "vlad",
             storage
         );
         final InvoicedTasks all = Mockito.mock(InvoicedTasks.class);
@@ -222,6 +234,8 @@ public final class StoredInvoiceTestCase {
             creationTime,
             LocalDateTime.now(),
             "transacetionId123",
+            "mihai",
+            "vlad",
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(
@@ -243,6 +257,8 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             paymentTime,
             "transactionId",
+            "mihai",
+            "vlad",
             storage
         );
         MatcherAssert.assertThat(
@@ -263,6 +279,8 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             paymentTime,
             "transactionId123",
+            "mihai",
+            "vlad",
             mock(Storage.class)
         );
         MatcherAssert.assertThat(
@@ -292,6 +310,8 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            "mihai",
+            "vlad",
             Mockito.mock(Storage.class)
         );
 
@@ -330,6 +350,8 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transactionId123",
+            "mihai",
+            "vlad",
             Mockito.mock(Storage.class)
         );
 
@@ -381,6 +403,8 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             null,
             null,
+            "mihai",
+            "vlad",
             storage
         );
 
@@ -414,6 +438,8 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            "mihai",
+            "vlad",
             Mockito.mock(Storage.class)
         );
         final Invoice invoiceTwo = new StoredInvoice(
@@ -422,6 +448,8 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            "mihai",
+            "vlad",
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(invoice, Matchers.equalTo(invoiceTwo));
@@ -438,6 +466,8 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            "mihai",
+            "vlad",
             Mockito.mock(Storage.class)
         );
         final Invoice invoiceTwo = new StoredInvoice(
@@ -446,6 +476,8 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            "mihai",
+            "vlad",
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(invoice.hashCode(),

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryInvoices.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryInvoices.java
@@ -72,6 +72,8 @@ public final class InMemoryInvoices implements Invoices {
             LocalDateTime.now(),
             null,
             null,
+            null,
+            null,
             this.storage
         );
         this.invoices.put(created.invoiceId(), created);


### PR DESCRIPTION
Fixes #811 

Implemented Invoice billedBy and billedTo.
If the two values are not set in the constructor, then they are read from the Contract.
The two values are written in the DB (thus can never change) when the invoice is paid.