### PR TITLE
#821 send BillingInfo to Stripe Connect

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Contributor.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Contributor.java
@@ -76,12 +76,13 @@ public interface Contributor {
     /**
      * Create a Stripe Connect Account for this Contributor,
      * so we can pay them. The Connect Account will be linked
-     * to the Self's Platform Accoung on Stripe.
+     * to the Self's Platform Account on Stripe.
+     * @param billingInfo Info associated with the Stripe Account.
      * @return PayoutMethod.
      * @throws IllegalStateException If the Contributor alredy has
      *  a Stripe Account/PayoutMethod.
      */
-    PayoutMethod createStripeAccount();
+    PayoutMethod createStripeAccount(final BillingInfo billingInfo);
 
     /**
      * Billing information of this Contributor. This information will

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contributors/StoredContributor.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contributors/StoredContributor.java
@@ -293,9 +293,15 @@ public final class StoredContributor implements Contributor {
     }
 
     /**
-     * Create AccountCreateParams for Stripe.
+     * Create AccountCreateParams for Stripe.<br><br>
+     *
+     * We duplicate almost all the info in the metadata field, so we
+     * can also retrieve it from Stripe. Otherwise, Stripe will not
+     * give us this info when fetching an Account.
+     *
      * @param info Billing info.
      * @return AccountCreateParams.
+     * @checkstyle ExecutableStatementCount (100 lines)
      */
     private AccountCreateParams accountParams(final BillingInfo info) {
         final AccountCreateParams.BusinessType businessType;
@@ -307,7 +313,8 @@ public final class StoredContributor implements Contributor {
             businessType = INDIVIDUAL;
             metadata.put("isCompany", "false");
         }
-        final AccountCreateParams.Builder account = AccountCreateParams.builder()
+        final AccountCreateParams.Builder account = AccountCreateParams
+            .builder()
             .setEmail(info.email())
             .setCountry(info.country())
             .setBusinessType(businessType)

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contributors/StoredContributorTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contributors/StoredContributorTestCase.java
@@ -309,7 +309,7 @@ public final class StoredContributorTestCase {
         Mockito.when(all.ofContributor(contributor)).thenReturn(ofContributor);
 
         try {
-            contributor.createStripeAccount();
+            contributor.createStripeAccount(Mockito.mock(BillingInfo.class));
             Assert.fail("IllegalStateException was expected.");
         } catch (final IllegalStateException ex) {
             Mockito.verify(ofContributor, Mockito.times(0)).register(
@@ -345,7 +345,7 @@ public final class StoredContributorTestCase {
         Mockito.when(all.ofContributor(contributor)).thenReturn(ofContributor);
 
         try {
-            contributor.createStripeAccount();
+            contributor.createStripeAccount(Mockito.mock(BillingInfo.class));
             Assert.fail("IllegalStateException was expected.");
         } catch (final IllegalStateException ex) {
             Mockito.verify(ofContributor, Mockito.times(0)).register(


### PR DESCRIPTION
Fixes #821 

We send the BillingInfo to Stripe Connect when creating a Connected Account.
The building logic is different on whether the Account is an Individual or a Company.