### PR TITLE
#838 GitlabCommitComment and GitlabIssueComment impl

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCommitComment.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCommitComment.java
@@ -1,0 +1,51 @@
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Comment;
+
+import javax.json.JsonObject;
+
+/**
+ * Gitlab commit comment.
+ *
+ * @author Ali Fellahi (fellahi.ali@gmail.com)
+ * @version $Id$
+ * @since 0.0.49
+ */
+final class GitlabCommitComment implements Comment {
+
+    /**
+     * Comment JSON as returned by Gitlab's API.
+     */
+    private final JsonObject json;
+
+    /**
+     * Ctor.
+     *
+     * @param json Comment JSON as returned by Gitlab's API.
+     */
+    GitlabCommitComment(final JsonObject json) {
+        this.json = json;
+    }
+
+    @Override
+    public String commentId() {
+        throw new UnsupportedOperationException(
+            "GitLab Commit Comment has no ID"
+        );
+    }
+
+    @Override
+    public String author() {
+        return this.json.getJsonObject("author").getString("username");
+    }
+
+    @Override
+    public String body() {
+        return this.json.getString("note");
+    }
+
+    @Override
+    public JsonObject json() {
+        return this.json;
+    }
+}

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabIssueComment.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabIssueComment.java
@@ -15,14 +15,14 @@ import javax.json.JsonObject;
 final class GitlabIssueComment implements Comment {
 
     /**
-     * Comment JSON as returned by Github's API.
+     * Comment JSON as returned by Gitlab's API.
      */
     private final JsonObject json;
 
     /**
      * Ctor.
      *
-     * @param json Comment JSON as returned by Github's API.
+     * @param json Comment JSON as returned by Gitlab's API.
      */
     GitlabIssueComment(final JsonObject json) {
         this.json = json;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabIssueComment.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabIssueComment.java
@@ -4,7 +4,7 @@ import com.selfxdsd.api.Comment;
 import javax.json.JsonObject;
 
 /**
- * Gitlab Comment.
+ * Gitlab Issue Comment.
  *
  * <a href="https://docs.gitlab.com/ee/api/notes.html#get-single-issue-note">Notes API</a>
  *
@@ -12,7 +12,7 @@ import javax.json.JsonObject;
  * @version $Id$
  * @since 0.0.45
  */
-final class GitlabComment implements Comment {
+final class GitlabIssueComment implements Comment {
 
     /**
      * Comment JSON as returned by Github's API.
@@ -24,7 +24,7 @@ final class GitlabComment implements Comment {
      *
      * @param json Comment JSON as returned by Github's API.
      */
-    GitlabComment(final JsonObject json) {
+    GitlabIssueComment(final JsonObject json) {
         this.json = json;
     }
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabIssueComments.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabIssueComments.java
@@ -59,7 +59,7 @@ final class GitlabIssueComments implements Comments {
             Json.createObjectBuilder().add("body", body).build()
         );
         if (resource.statusCode() == HttpURLConnection.HTTP_CREATED) {
-            return new GitlabComment(resource.asJsonObject());
+            return new GitlabIssueComment(resource.asJsonObject());
         } else {
             LOG.error(
                 "Expected status 201 CREATED, but got: [{}].",
@@ -76,7 +76,7 @@ final class GitlabIssueComments implements Comments {
 
     @Override
     public Comment received(final JsonObject comment) {
-        return new GitlabComment(comment);
+        return new GitlabIssueComment(comment);
     }
 
     @Override

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCommitCommentTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCommitCommentTestCase.java
@@ -1,0 +1,79 @@
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Comment;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+
+/**
+ * Unit tests for {@link GitlabCommitComment}.
+ *
+ * @author Ali Fellahi (fellahi.ali@gmail.com)
+ * @version $Id$
+ * @since 0.0.49
+ */
+public final class GitlabCommitCommentTestCase {
+
+    /**
+     * Gitlab commit comment doesn't have an id.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void commitIdIsNotSupported() {
+        new GitlabCommitComment(Mockito.mock(JsonObject.class)).commentId();
+    }
+
+    /**
+     * Commit comment can return its author.
+     */
+    @Test
+    public void canReturnItsAuthor() {
+        final Comment comment = new GitlabCommitComment(
+            Json.createObjectBuilder()
+                .add(
+                    "author",
+                    Json.createObjectBuilder()
+                        .add("username", "alilo")
+                )
+                .build()
+        );
+        MatcherAssert.assertThat(
+            comment.author(),
+            Matchers.equalTo("alilo")
+        );
+    }
+
+    /**
+     * Commit comment can return its body.
+     */
+    @Test
+    public void canReturnItsBody() {
+        final Comment comment = new GitlabCommitComment(
+            Json.createObjectBuilder()
+                .add("note", "test")
+                .build()
+        );
+        MatcherAssert.assertThat(
+            comment.body(),
+            Matchers.equalTo("test")
+        );
+    }
+
+    /**
+     * Commit comment can return its original JsonObject.
+     */
+    @Test
+    public void canReturnItsOriginalJson() {
+        JsonObject json = Json.createObjectBuilder()
+            .add("note", "This is a comment")
+            .build();
+        final Comment comment = new GitlabIssueComment(json);
+        MatcherAssert.assertThat(
+            comment.json(),
+            Matchers.is(json)
+        );
+    }
+}

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabIssueCommentTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabIssueCommentTestCase.java
@@ -8,12 +8,12 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Unit tests for {@link GitlabComment}.
+ * Unit tests for {@link GitlabIssueComment}.
  *
  * @version $Id$
  * @since 0.0.45
  */
-public final class GitlabCommentTestCase {
+public final class GitlabIssueCommentTestCase {
 
     /**
      * Extracts author, id and comment
@@ -22,7 +22,7 @@ public final class GitlabCommentTestCase {
     @Test
     public void returnsAuthor() {
         MatcherAssert.assertThat(
-            new GitlabComment(
+            new GitlabIssueComment(
                 Json.createObjectBuilder()
                     .add("id", 1)
                     .add(
@@ -50,7 +50,7 @@ public final class GitlabCommentTestCase {
             .add("id", 1)
             .add("body", "This is a comment")
             .build();
-        final Comment comment = new GitlabComment(json);
+        final Comment comment = new GitlabIssueComment(json);
         MatcherAssert.assertThat(
             comment.json(),
             Matchers.is(json)

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabIssueCommentsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabIssueCommentsTestCase.java
@@ -154,7 +154,7 @@ public final class GitlabIssueCommentsTestCase {
             comment,
             Matchers.allOf(
                 Matchers.notNullValue(),
-                Matchers.instanceOf(GitlabComment.class)
+                Matchers.instanceOf(GitlabIssueComment.class)
             )
         );
         MatcherAssert.assertThat(
@@ -203,7 +203,7 @@ public final class GitlabIssueCommentsTestCase {
             comment,
             Matchers.allOf(
                 Matchers.notNullValue(),
-                Matchers.instanceOf(GitlabComment.class)
+                Matchers.instanceOf(GitlabIssueComment.class)
             )
         );
         MatcherAssert.assertThat(


### PR DESCRIPTION
Fixes #838
We now have 2 type of comments for Gitlab API, one for issues and other for commits, because of the difference in JSON representation.   