### PR TITLE
#852 Making Collaborators an iterable of Collaborator

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Collaborator.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Collaborator.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2020-2021, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.api;
+
+import javax.json.JsonObject;
+
+/**
+ * Repo collaborator.
+ * @author Ali Fellahi (fellahi.ali@gmail.com)
+ * @version $Id$
+ * @since 0.0.49
+ */
+public interface Collaborator {
+    /**
+     *
+     * @return int.
+     */
+    int id();
+
+    /**
+     *
+     * @return String.
+     */
+    String username();
+
+    /**
+     *
+     * @return String.
+     */
+    String name();
+
+    /**
+     *
+     * @return JsonObject.
+     */
+    JsonObject json();
+}

--- a/self-api/src/main/java/com/selfxdsd/api/Collaborator.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Collaborator.java
@@ -33,9 +33,9 @@ import javax.json.JsonObject;
 public interface Collaborator {
     /**
      *
-     * @return int.
+     * @return Integer.
      */
-    int id();
+    int collaboratorId();
 
     /**
      *

--- a/self-api/src/main/java/com/selfxdsd/api/Collaborator.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Collaborator.java
@@ -32,24 +32,28 @@ import javax.json.JsonObject;
  */
 public interface Collaborator {
     /**
+     * The id of the Collaborator.
      *
      * @return Integer.
      */
     int collaboratorId();
 
     /**
+     * The username as registered in the provider's platform.
      *
      * @return String.
      */
     String username();
 
     /**
+     * The full name.
      *
      * @return String.
      */
     String name();
 
     /**
+     * The JSON representation as returned by the provider.
      *
      * @return JsonObject.
      */

--- a/self-api/src/main/java/com/selfxdsd/api/Collaborators.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Collaborators.java
@@ -28,7 +28,7 @@ package com.selfxdsd.api;
  * @version $Id$
  * @since 0.0.13
  */
-public interface Collaborators {
+public interface Collaborators extends Iterable<Collaborator> {
 
     /**
      * Invite a user to be a collaborator.

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubCollaborators.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubCollaborators.java
@@ -22,6 +22,7 @@
  */
 package com.selfxdsd.core;
 
+import com.selfxdsd.api.Collaborator;
 import com.selfxdsd.api.Collaborators;
 import com.selfxdsd.api.storage.Storage;
 import org.slf4j.Logger;
@@ -30,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import javax.json.Json;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.util.Iterator;
 
 /**
  * Github repo collaborators.
@@ -138,5 +140,12 @@ final class GithubCollaborators implements Collaborators {
             );
         }
         return result;
+    }
+
+    @Override
+    public Iterator<Collaborator> iterator() {
+        throw new UnsupportedOperationException(
+            "We can't iterate over a Github repo's collaborators for now."
+        );
     }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborator.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborator.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2020-2021, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Collaborator;
+
+import javax.json.JsonObject;
+
+/**
+ * Gitlab collaborator.
+ * @author Ali Fellahi (fellahi.ali@gmail.com)
+ * @version $Id$
+ * @since 0.0.49
+ */
+public final class GitlabCollaborator implements Collaborator {
+
+    /**
+     * JSON representation of Gitlab collaborator.
+     */
+    private final JsonObject json;
+
+    /**
+     * Ctor.
+     *
+     * @param json Representation of Gitlab collaborator.
+     */
+    public GitlabCollaborator(JsonObject json) {
+        this.json = json;
+    }
+
+    @Override
+    public int collaboratorId() {
+        return json.getInt("id");
+    }
+
+    @Override
+    public String username() {
+        return json.getString("username");
+    }
+
+    @Override
+    public String name() {
+        return json.getString("name");
+    }
+
+    @Override
+    public JsonObject json() {
+        return json;
+    }
+}

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborator.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborator.java
@@ -44,7 +44,7 @@ public final class GitlabCollaborator implements Collaborator {
      *
      * @param json Representation of Gitlab collaborator.
      */
-    public GitlabCollaborator(JsonObject json) {
+    public GitlabCollaborator(final JsonObject json) {
         this.json = json;
     }
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborators.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborators.java
@@ -19,6 +19,8 @@ import java.util.stream.Collectors;
  * @author criske
  * @version $Id$
  * @since 0.0.13
+ * @todo #852:30min Write unit tests for the iterator()
+ *  happy and unhappy paths.
  */
 final class GitlabCollaborators implements Collaborators {
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborators.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborators.java
@@ -147,11 +147,12 @@ final class GitlabCollaborators implements Collaborators {
                 .map(GitlabCollaborator::new)
                 .collect(Collectors.toList());
         } else {
-            throw new IllegalStateException(
+            LOG.error(
                 "Unable to fetch Gitlab collaborators"
                     + " from [" + this.collaboratorsUri.toString() + "],"
                     + " 200 was expected but we got " + response.statusCode()
             );
+            collaborators = List.of();
         }
         return collaborators.iterator();
     }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborators.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborators.java
@@ -135,8 +135,8 @@ final class GitlabCollaborators implements Collaborators {
     @Override
     public Iterator<Collaborator> iterator() {
         LOG.debug(
-            "Fetching Gitlab's repo collaborators " +
-            "from [" + this.collaboratorsUri.toString() + "]."
+            "Fetching Gitlab's repo collaborators "
+                + "from [" + this.collaboratorsUri.toString() + "]."
         );
         final Resource response = this.resources.get(this.collaboratorsUri);
         final List<Collaborator> collaborators;
@@ -148,9 +148,9 @@ final class GitlabCollaborators implements Collaborators {
                 .collect(Collectors.toList());
         } else {
             throw new IllegalStateException(
-                "Unable to fetch Gitlab collaborators" +
-                " from [" + this.collaboratorsUri.toString() + "]," +
-                " 200 was expected but we got " + response.statusCode()
+                "Unable to fetch Gitlab collaborators"
+                    + " from [" + this.collaboratorsUri.toString() + "],"
+                    + " 200 was expected but we got " + response.statusCode()
             );
         }
         return collaborators.iterator();

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubCollaboratorsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubCollaboratorsTestCase.java
@@ -34,6 +34,7 @@ import org.mockito.Mockito;
 import javax.json.Json;
 import javax.json.JsonValue;
 import java.net.HttpURLConnection;
+import java.net.URI;
 
 /**
  * Unit tests for {@link GithubCollaborators}.
@@ -304,4 +305,15 @@ public final class GithubCollaboratorsTestCase {
         );
     }
 
+    /**
+     * {@link GithubCollaborators} can't iterate over collaborators.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void cantIterateOverCollaborators() {
+        new GithubCollaborators(
+            Mockito.mock(JsonResources.class),
+            URI.create("test"),
+            Mockito.mock(Storage.class)
+        ).iterator();
+    }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCollaboratorTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCollaboratorTestCase.java
@@ -22,16 +22,12 @@
  */
 package com.selfxdsd.core;
 
-import com.selfxdsd.api.Commit;
-import com.selfxdsd.api.storage.Storage;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import javax.json.Json;
 import javax.json.JsonObject;
-import java.net.URI;
 
 /**
  * Unit tests for {@link GitlabCollaborator}.

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCollaboratorTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCollaboratorTestCase.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2020-2021, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Commit;
+import com.selfxdsd.api.storage.Storage;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import java.net.URI;
+
+/**
+ * Unit tests for {@link GitlabCollaborator}.
+ * @author Ali Fellahi (fellahi.ali@gmail.com)
+ * @version $Id$
+ * @since 0p.0.49
+ */
+public final class GitlabCollaboratorTestCase {
+
+    /**
+     * Gitlab collaborator can return its id.
+     */
+    @Test
+    public void canReturnItsId() {
+        MatcherAssert.assertThat(
+            new GitlabCollaborator(
+                Json.createObjectBuilder().add("id", 1).build()
+            ).collaboratorId(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    /**
+     * Gitlab collaborator can return its username.
+     */
+    @Test
+    public void canReturnItsUsername() {
+        MatcherAssert.assertThat(
+            new GitlabCollaborator(
+                Json.createObjectBuilder().add("username", "alilo").build()
+            ).username(),
+            Matchers.equalTo("alilo")
+        );
+    }
+
+    /**
+     * Gitlab collaborator can return its name.
+     */
+    @Test
+    public void canReturnItsName() {
+        MatcherAssert.assertThat(
+            new GitlabCollaborator(
+                Json.createObjectBuilder().add("name", "Ali Fellahi").build()
+            ).name(),
+            Matchers.equalTo("Ali Fellahi")
+        );
+    }
+
+    /**
+     * Gitlab collaborator can return its original json.
+     */
+    @Test
+    public void canReturnItsJson() {
+        final JsonObject json = Json.createObjectBuilder().build();
+        MatcherAssert.assertThat(
+            new GitlabCollaborator(json).json(),
+            Matchers.is(json)
+        );
+    }
+}


### PR DESCRIPTION
PR for #852 
- Add `Collaborator` interface and implement `GitlabCollaborator`
- Make `Collaborators` and `Iterable` of `Collaborator` 