### PR TITLE
#855 Implemented Invoice.contributorVat()

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Invoice.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Invoice.java
@@ -54,6 +54,14 @@ public interface Invoice {
     String transactionId();
 
     /**
+     * VAT which Self takes from the Contributor.
+     * @return BigDecimal. It will always be 0 until the
+     *  Invoice is paid. When the Invoice is paid, we set
+     *  this value for later reference.
+     */
+    BigDecimal contributorVat();
+
+    /**
      * Who emitted the Invoice?
      * @return String.
      */

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/StoredInvoice.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/StoredInvoice.java
@@ -54,6 +54,11 @@ public final class StoredInvoice implements Invoice {
     private final String transactionId;
 
     /**
+     * The VAT which Self XDSD takes from the Contributor.
+     */
+    private final BigDecimal contributorVat;
+
+    /**
      * Who emitted this Invoice?
      */
     private final String billedBy;
@@ -75,6 +80,7 @@ public final class StoredInvoice implements Invoice {
      * @param createdAt Invoice creation time.
      * @param paymentTime Time when this Invoice has been paid.
      * @param transactionId The payment's transaction ID.
+     * @param contributorVat The VAT which Self takes from the Contributor.
      * @param billedBy Who emitted the Invoice.
      * @param billedTo Who pays it.
      * @param storage Self storage context.
@@ -85,6 +91,7 @@ public final class StoredInvoice implements Invoice {
         final LocalDateTime createdAt,
         final LocalDateTime paymentTime,
         final String transactionId,
+        final BigDecimal contributorVat,
         final String billedBy,
         final String billedTo,
         final Storage storage
@@ -94,6 +101,7 @@ public final class StoredInvoice implements Invoice {
         this.createdAt = createdAt;
         this.paymentTime = paymentTime;
         this.transactionId = transactionId;
+        this.contributorVat = contributorVat;
         this.billedBy = billedBy;
         this.billedTo = billedTo;
         this.storage = storage;
@@ -149,6 +157,11 @@ public final class StoredInvoice implements Invoice {
     @Override
     public String transactionId() {
         return this.transactionId;
+    }
+
+    @Override
+    public BigDecimal contributorVat() {
+        return this.contributorVat;
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
@@ -140,7 +140,8 @@ public final class FakeWallet implements Wallet {
                     invoice.contract(),
                     invoice.createdAt(),
                     LocalDateTime.now(),
-                    "not_paid_" + uuid,
+                    "fake_payment_" + uuid,
+                    BigDecimal.valueOf(0),
                     invoice.billedBy(),
                     invoice.billedTo(),
                     this.storage

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
@@ -271,6 +271,7 @@ public final class StripeWallet implements Wallet {
                             invoice.createdAt(),
                             paymentDate,
                             paymentIntent.getId(),
+                            vat,
                             invoice.billedBy(),
                             invoice.billedTo(),
                             this.storage

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
@@ -51,11 +51,6 @@ import java.util.Objects;
  * @version $Id$
  * @since 0.0.27
  * @checkstyle ExecutableStatementCount (1000 lines)
- * @todo #853:90min After payment, when registering the Invoice as paid,
- *  we should also send the VAT and save it on the Invoice as payment
- *  indicator (together with payment time and transaction ID). Then, when
- *  printing Self's invoice to the Contributor we will know whether the
- *  Contributor was charged VAT or not.
  */
 public final class StripeWallet implements Wallet {
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/StoredInvoiceTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/StoredInvoiceTestCase.java
@@ -35,6 +35,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             Mockito.mock(Storage.class)
@@ -54,6 +55,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             Mockito.mock(Storage.class)
@@ -73,6 +75,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transactionID",
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             storage
@@ -111,6 +114,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transactionID",
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             storage
@@ -152,6 +156,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transactionID",
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             storage
@@ -193,6 +198,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transactionID",
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             storage
@@ -234,6 +240,7 @@ public final class StoredInvoiceTestCase {
             creationTime,
             LocalDateTime.now(),
             "transacetionId123",
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             Mockito.mock(Storage.class)
@@ -257,6 +264,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             paymentTime,
             "transactionId",
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             storage
@@ -279,6 +287,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             paymentTime,
             "transactionId123",
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             mock(Storage.class)
@@ -286,6 +295,29 @@ public final class StoredInvoiceTestCase {
         MatcherAssert.assertThat(
             invoice.transactionId(),
             Matchers.is("transactionId123")
+        );
+    }
+
+    /**
+     * A StoredInvoice can return its contributor VAT.
+     */
+    @Test
+    public void hasContributorVat() {
+        final LocalDateTime paymentTime = LocalDateTime.now();
+        final Invoice invoice = new StoredInvoice(
+            1,
+            Mockito.mock(Contract.class),
+            LocalDateTime.now(),
+            paymentTime,
+            "transactionId123",
+            BigDecimal.valueOf(15),
+            "mihai",
+            "vlad",
+            mock(Storage.class)
+        );
+        MatcherAssert.assertThat(
+            invoice.contributorVat(),
+            Matchers.equalTo(BigDecimal.valueOf(15))
         );
     }
 
@@ -310,6 +342,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             Mockito.mock(Storage.class)
@@ -350,6 +383,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transactionId123",
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             Mockito.mock(Storage.class)
@@ -403,6 +437,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             null,
             null,
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             storage
@@ -438,6 +473,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             Mockito.mock(Storage.class)
@@ -448,6 +484,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             Mockito.mock(Storage.class)
@@ -466,6 +503,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             Mockito.mock(Storage.class)
@@ -476,6 +514,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             Mockito.mock(Storage.class)
@@ -497,6 +536,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             Mockito.mock(Storage.class)
@@ -520,6 +560,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            BigDecimal.valueOf(0),
             "mihai",
             "vlad",
             Mockito.mock(Storage.class)
@@ -549,6 +590,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            BigDecimal.valueOf(0),
             null,
             "vlad",
             Mockito.mock(Storage.class)
@@ -578,6 +620,7 @@ public final class StoredInvoiceTestCase {
             LocalDateTime.now(),
             LocalDateTime.now(),
             "transacetionId123",
+            BigDecimal.valueOf(0),
             "mihai",
             null,
             Mockito.mock(Storage.class)

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryInvoices.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryInvoices.java
@@ -5,6 +5,7 @@ import com.selfxdsd.api.storage.Storage;
 import com.selfxdsd.core.contracts.invoices.ContractInvoices;
 import com.selfxdsd.core.contracts.invoices.StoredInvoice;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.StreamSupport;
@@ -72,6 +73,7 @@ public final class InMemoryInvoices implements Invoices {
             LocalDateTime.now(),
             null,
             null,
+            BigDecimal.valueOf(0),
             null,
             null,
             this.storage


### PR DESCRIPTION
PR for #855 

The contributorVat on the Invoice is a payment flag, together with paymentTime and transactionId.
It's being set after the Invoice is successfully paid.