### PR TITLE
#889 cancel PaymentIntent when status is not ok

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
@@ -274,6 +274,9 @@ public final class StripeWallet implements Wallet {
                     );
             } else {
                 LOG.error("[STRIPE] PaymentIntent status: " + status);
+                LOG.error("[STRIPE] Cancelling PaymentIntent...");
+                paymentIntent.cancel();
+                LOG.error("[STRIPE] PaymentIntent successfully cancelled.");
                 throw new WalletPaymentException(
                     "Could not pay invoice #" + invoice.invoiceId() + " due to"
                     + " Stripe payment intent status \"" + status + "\""


### PR DESCRIPTION
Fixes #889 
If status of the PaymentIntent is not ``succeeded`` or ``processing``, we cancel it.