### PR TITLE
#891 registerAsPaid with EUR-RON exchange rate

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Invoices.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Invoices.java
@@ -46,9 +46,13 @@ public interface Invoices extends Iterable<Invoice> {
      * Register an Invoice as paid.
      * @param invoice Paid invoice.
      * @param contributorVat Vat which Self takes from the Contributor.
+     * @param eurToRon Euro to RON (Romanian Leu) conversion rate.
+     *  For example, if the value is 487, it means 1 EUR = 4,87 RON.
      * @return True or false, depending on whether the operation succeeded.
      */
     boolean registerAsPaid(
-        final Invoice invoice, final BigDecimal contributorVat
+        final Invoice invoice,
+        final BigDecimal contributorVat,
+        final BigDecimal eurToRon
     );
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/ContractInvoices.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/ContractInvoices.java
@@ -91,14 +91,18 @@ public final class ContractInvoices implements Invoices {
 
     @Override
     public boolean registerAsPaid(
-        final Invoice invoice, final BigDecimal contributorVat
+        final Invoice invoice,
+        final BigDecimal contributorVat,
+        final BigDecimal eurToRon
     ) {
         if(!invoice.contract().contractId().equals(this.contractId)){
             throw new IllegalStateException(
                 "The given Invoice belongs to another contract."
             );
         }
-        return this.storage.invoices().registerAsPaid(invoice, contributorVat);
+        return this.storage.invoices().registerAsPaid(
+            invoice, contributorVat, eurToRon
+        );
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
@@ -145,6 +145,7 @@ public final class FakeWallet implements Wallet {
                     invoice.billedTo(),
                     this.storage
                 ),
+                BigDecimal.valueOf(0),
                 BigDecimal.valueOf(0)
             );
         if (!paid) {

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
@@ -51,6 +51,9 @@ import java.util.Objects;
  * @version $Id$
  * @since 0.0.27
  * @checkstyle ExecutableStatementCount (1000 lines)
+ * @todo #891:60min At the moment the registered EUR to RON exchange
+ *  rate is always 487 (1 EUR = 4,87 RON). Let's read it from somewhere,
+ *  probably using API of the BNR (Romanian National Bank).
  */
 public final class StripeWallet implements Wallet {
 
@@ -270,7 +273,8 @@ public final class StripeWallet implements Wallet {
                             invoice.billedTo(),
                             this.storage
                         ),
-                        vat
+                        vat,
+                        BigDecimal.valueOf(487)
                     );
             } else {
                 LOG.error("[STRIPE] PaymentIntent status: " + status);

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/ContractInvoicesTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/ContractInvoicesTestCase.java
@@ -206,6 +206,8 @@ public final class ContractInvoicesTestCase {
     @Test
     public void registersPaidInvoice() {
         final BigDecimal contributorVat = BigDecimal.valueOf(3);
+        final BigDecimal eurToRon = BigDecimal.valueOf(487);
+
         final Invoice invoice = Mockito.mock(Invoice.class);
         final Contract contract = Mockito.mock(Contract.class);
         Mockito.when(invoice.contract()).thenReturn(contract);
@@ -220,7 +222,7 @@ public final class ContractInvoicesTestCase {
 
         final Invoices all = Mockito.mock(Invoices.class);
         Mockito.when(
-            all.registerAsPaid(invoice, contributorVat)
+            all.registerAsPaid(invoice, contributorVat, eurToRon)
         ).thenReturn(Boolean.TRUE);
         final Storage storage = Mockito.mock(Storage.class);
         Mockito.when(storage.invoices()).thenReturn(all);
@@ -232,7 +234,7 @@ public final class ContractInvoicesTestCase {
         );
 
         MatcherAssert.assertThat(
-            invoices.registerAsPaid(invoice, contributorVat),
+            invoices.registerAsPaid(invoice, contributorVat, eurToRon),
             Matchers.is(Boolean.TRUE)
         );
     }
@@ -244,6 +246,8 @@ public final class ContractInvoicesTestCase {
     @Test (expected = IllegalStateException.class)
     public void registerPaidInvoiceComplainsOnDifferentContract() {
         final BigDecimal contributorVat = BigDecimal.valueOf(3);
+        final BigDecimal eurToRon = BigDecimal.valueOf(487);
+
         final Invoice invoice = Mockito.mock(Invoice.class);
         final Contract contract = Mockito.mock(Contract.class);
         Mockito.when(invoice.contract()).thenReturn(contract);
@@ -264,7 +268,7 @@ public final class ContractInvoicesTestCase {
 
         final Invoices all = Mockito.mock(Invoices.class);
         Mockito.when(
-            all.registerAsPaid(invoice, contributorVat)
+            all.registerAsPaid(invoice, contributorVat, eurToRon)
         ).thenReturn(Boolean.TRUE);
         final Storage storage = Mockito.mock(Storage.class);
         Mockito.when(storage.invoices()).thenReturn(all);
@@ -276,7 +280,7 @@ public final class ContractInvoicesTestCase {
         );
 
         MatcherAssert.assertThat(
-            invoices.registerAsPaid(invoice, contributorVat),
+            invoices.registerAsPaid(invoice, contributorVat, eurToRon),
             Matchers.is(Boolean.TRUE)
         );
     }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryInvoices.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryInvoices.java
@@ -57,7 +57,8 @@ public final class InMemoryInvoices implements Invoices {
     @Override
     public boolean registerAsPaid(
         final Invoice invoice,
-        final BigDecimal contributorVat
+        final BigDecimal contributorVat,
+        final BigDecimal eurToRon
     ) {
         this.invoices.put(invoice.invoiceId(), invoice);
         return true;

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/FakeWalletTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/FakeWalletTestCase.java
@@ -398,6 +398,7 @@ public final class FakeWalletTestCase {
         Mockito.when(
             invoices.registerAsPaid(
                 Mockito.any(Invoice.class),
+                Mockito.any(BigDecimal.class),
                 Mockito.any(BigDecimal.class)
             )
         ).thenReturn(true);
@@ -418,6 +419,7 @@ public final class FakeWalletTestCase {
         Mockito.verify(invoices, Mockito.times(1))
             .registerAsPaid(
                 paidInvoiceCapture.capture(),
+                Mockito.any(BigDecimal.class),
                 Mockito.any(BigDecimal.class)
             );
         final Invoice paidInvoice = paidInvoiceCapture.getValue();
@@ -456,6 +458,7 @@ public final class FakeWalletTestCase {
         Mockito.when(
             invoices.registerAsPaid(
                 Mockito.any(Invoice.class),
+                Mockito.any(BigDecimal.class),
                 Mockito.any(BigDecimal.class)
             )
         ).thenReturn(false);

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/StripeWalletITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/StripeWalletITCase.java
@@ -144,6 +144,7 @@ public final class StripeWalletITCase {
             Mockito.verify(invoices, Mockito.times(1))
                 .registerAsPaid(
                     Mockito.any(Invoice.class),
+                    Mockito.any(BigDecimal.class),
                     Mockito.any(BigDecimal.class)
                 );
             Mockito.verify(ofProject, Mockito.times(1))


### PR DESCRIPTION
Fixes #891 

Added the EUR-RON exhange rate to Invoices.registerAsPaid(...);
Left puzzle to read this exchange rate from some API (in the case of real Stripe payment);