### PR TITLE
#894 XmlBnr implemented and used in StripeWallet

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Bnr.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Bnr.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2020-2021, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.api;
+
+import java.math.BigDecimal;
+
+/**
+ * Banca Nationala a Romaniei (Romanian National Bank).
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.51
+ */
+public interface Bnr {
+
+    /**
+     * Get the EUR to RON exchange rate. For example,
+     * if 1 EUR = 4,87 RON, it will return 487.
+     * @return BigDecimal. If there are any problems (e.g. we
+     * cannot fetch or parse the XML, we return 487 as default).
+     */
+    BigDecimal euroToRon();
+
+}

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
@@ -51,9 +51,6 @@ import java.util.Objects;
  * @version $Id$
  * @since 0.0.27
  * @checkstyle ExecutableStatementCount (1000 lines)
- * @todo #891:60min At the moment the registered EUR to RON exchange
- *  rate is always 487 (1 EUR = 4,87 RON). Let's read it from somewhere,
- *  probably using API of the BNR (Romanian National Bank).
  */
 public final class StripeWallet implements Wallet {
 
@@ -274,7 +271,7 @@ public final class StripeWallet implements Wallet {
                             this.storage
                         ),
                         vat,
-                        BigDecimal.valueOf(487)
+                        new XmlBnr().euroToRon()
                     );
             } else {
                 LOG.error("[STRIPE] PaymentIntent status: " + status);

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/XmlBnr.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/XmlBnr.java
@@ -47,6 +47,7 @@ import java.net.http.HttpResponse;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.51
+ * @checkstyle ReturnCount (200 lines)
  */
 final class XmlBnr implements Bnr {
 
@@ -75,7 +76,10 @@ final class XmlBnr implements Bnr {
                 );
             return readEurFromXml(response.body());
         } catch (final IOException | InterruptedException ex) {
-            LOG.error("[BNR] Could not get EUR-RON exchange rate: ", ex.getMessage());
+            LOG.error(
+                "[BNR] Could not get EUR-RON exchange rate: ",
+                ex.getMessage()
+            );
             LOG.error("[BNR] Returning 487 as default exchange rate.");
             return BigDecimal.valueOf(487);
         }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/XmlBnr.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/XmlBnr.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2020-2021, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core.projects;
+
+import com.selfxdsd.api.Bnr;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.io.StringReader;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+/**
+ * BNR gives us an XML response.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.51
+ */
+final class XmlBnr implements Bnr {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(
+        XmlBnr.class
+    );
+
+    /**
+     * BNR exchange rate URI.
+     */
+    private final URI uri = URI.create("https://www.bnr.ro/nbrfxrates.xml");
+
+    @Override
+    public BigDecimal euroToRon() {
+        try {
+            final HttpResponse<String> response = HttpClient.newHttpClient()
+                .send(
+                    HttpRequest.newBuilder()
+                        .uri(this.uri)
+                        .method("GET", HttpRequest.BodyPublishers.noBody())
+                        .build(),
+                    HttpResponse.BodyHandlers.ofString()
+                );
+            return readEurFromXml(response.body());
+        } catch (final IOException | InterruptedException ex) {
+            LOG.error("[BNR] Could not get EUR-RON exchange rate: ", ex.getMessage());
+            LOG.error("[BNR] Returning 487 as default exchange rate.");
+            return BigDecimal.valueOf(487);
+        }
+    }
+
+    /**
+     * Parse the response XML to get the EUR -> RON exchange rage.
+     * @param xml XML String.
+     * @return BigDecimal.
+     * @checkstyle LineLength (100 lines)
+     */
+    private BigDecimal readEurFromXml(final String xml) {
+        try {
+            final Document document = DocumentBuilderFactory
+                .newInstance()
+                .newDocumentBuilder()
+                .parse(new InputSource(new StringReader(xml)));
+            final NodeList rates = document
+                .getDocumentElement()
+                .getElementsByTagName("Rate");
+            for(int idx=0; idx<rates.getLength(); idx++) {
+                final Node rate = rates.item(idx);
+                final String name = rate.getAttributes()
+                    .getNamedItem("currency").getTextContent();
+                if("EUR".equalsIgnoreCase(name)) {
+                    final String text = rate.getTextContent();
+                    LOG.info("[BNR] Found EUR-RON exchange rate: " + text);
+                    LOG.info("[BNR] Rounding Half-Up to 2 decimals.");
+                    return new BigDecimal(
+                        text
+                    ).setScale(2, RoundingMode.HALF_UP);
+                }
+            }
+            LOG.warn("[BNR] EUR-RON not found! Returning 487 as default.");
+            return BigDecimal.valueOf(487);
+        } catch (final SAXException | IOException | ParserConfigurationException ex) {
+            LOG.error("[BNR] Exception while parsing XML: ", ex.getMessage());
+            LOG.error("[BNR] Returning 487 as default exchange rate.");
+            return BigDecimal.valueOf(487);
+        }
+    }
+}


### PR DESCRIPTION
PR for #894 

Implemented Bnr and XmlBnr to fetch the EUR-RON exchagne rate from the Romanian National Bank;
Changed StripeWallet to send the BNR exchange rate when registering an Invoice as paid;