### PR TITLE
AccesToken.Gitlab updated to use "Authorization" header.

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/AccessToken.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/AccessToken.java
@@ -75,12 +75,12 @@ public interface AccessToken {
 
         @Override
         public String header() {
-            return "Private-Token";
+            return "Authorization";
         }
 
         @Override
         public String value() {
-            return this.value;
+            return "Bearer " + this.value;
         }
     }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/AccessTokenTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/AccessTokenTestCase.java
@@ -31,8 +31,8 @@ public final class AccessTokenTestCase {
     public void representsGitlabAccessToken(){
         final AccessToken token = new AccessToken.Gitlab("gitlab123");
         MatcherAssert.assertThat(token.header(),
-            Matchers.equalTo("Private-Token"));
+            Matchers.equalTo("Authorization"));
         MatcherAssert.assertThat(token.value(),
-            Matchers.equalTo("gitlab123"));
+            Matchers.equalTo("Bearer gitlab123"));
     }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCollaboratorsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCollaboratorsTestCase.java
@@ -60,7 +60,7 @@ public final class GitlabCollaboratorsTestCase {
                 req -> {
                     MatcherAssert.assertThat(
                         req.getAccessToken().value(),
-                        Matchers.equalTo("gitlab123")
+                        Matchers.equalTo("Bearer gitlab123")
                     );
                     MatcherAssert.assertThat(
                         req.getMethod(),
@@ -110,7 +110,7 @@ public final class GitlabCollaboratorsTestCase {
                 req -> {
                     MatcherAssert.assertThat(
                         req.getAccessToken().value(),
-                        Matchers.equalTo("gitlab123")
+                        Matchers.equalTo("Bearer gitlab123")
                     );
                     MatcherAssert.assertThat(
                         req.getMethod(),
@@ -160,7 +160,7 @@ public final class GitlabCollaboratorsTestCase {
                 req -> {
                     MatcherAssert.assertThat(
                         req.getAccessToken().value(),
-                        Matchers.equalTo("gitlab123")
+                        Matchers.equalTo("Bearer gitlab123")
                     );
                     MatcherAssert.assertThat(
                         req.getMethod(),
@@ -209,7 +209,7 @@ public final class GitlabCollaboratorsTestCase {
                 req -> {
                     MatcherAssert.assertThat(
                         req.getAccessToken().value(),
-                        Matchers.equalTo("gitlab123")
+                        Matchers.equalTo("Bearer gitlab123")
                     );
                     MatcherAssert.assertThat(
                         req.getMethod(),
@@ -258,7 +258,7 @@ public final class GitlabCollaboratorsTestCase {
                 req -> {
                     MatcherAssert.assertThat(
                         req.getAccessToken().value(),
-                        Matchers.equalTo("gitlab123")
+                        Matchers.equalTo("Bearer gitlab123")
                     );
                     MatcherAssert.assertThat(
                         req.getMethod(),

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabIssuesTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabIssuesTestCase.java
@@ -205,7 +205,7 @@ public final class GitlabIssuesTestCase {
                 req -> {
                     MatcherAssert.assertThat(
                         req.getAccessToken().value(),
-                        Matchers.equalTo("gitlab123")
+                        Matchers.equalTo("Bearer gitlab123")
                     );
                     MatcherAssert.assertThat(
                         req.getMethod(),
@@ -356,7 +356,7 @@ public final class GitlabIssuesTestCase {
                 req -> {
                     MatcherAssert.assertThat(
                         req.getAccessToken().value(),
-                        Matchers.equalTo("gitlab123")
+                        Matchers.equalTo("Bearer gitlab123")
                     );
                     MatcherAssert.assertThat(
                         req.getMethod(),

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabWebhooksTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabWebhooksTestCase.java
@@ -59,7 +59,7 @@ public final class GitlabWebhooksTestCase {
                 req -> {
                     MatcherAssert.assertThat(
                         req.getAccessToken().value(),
-                        Matchers.equalTo("gitlab123")
+                        Matchers.equalTo("Bearer gitlab123")
                     );
                     MatcherAssert.assertThat(
                         req.getMethod(),
@@ -139,7 +139,7 @@ public final class GitlabWebhooksTestCase {
                 req -> {
                     MatcherAssert.assertThat(
                         req.getAccessToken().value(),
-                        Matchers.equalTo("gitlab123")
+                        Matchers.equalTo("Bearer gitlab123")
                     );
                     MatcherAssert.assertThat(
                         req.getMethod(),
@@ -186,7 +186,7 @@ public final class GitlabWebhooksTestCase {
                 req -> {
                     MatcherAssert.assertThat(
                         req.getAccessToken().value(),
-                        Matchers.equalTo("gitlab123")
+                        Matchers.equalTo("Bearer gitlab123")
                     );
                     MatcherAssert.assertThat(
                         req.getMethod(),


### PR DESCRIPTION
Tokens generated with `self-web` will not work with `Private-Token` header (returns 401).
`AccesToken.Gitlab` has now the following config:
- header: `Authorization`
- value: `Bearer <token>`

--
Tested with a token generated with 'self-web' and now works fine.
No bounty needed, this is part of https://github.com/self-xdsd/self-web/issues/335
