### PR TITLE
#912 Read GitlabCommit author from Collaborators

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborators.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborators.java
@@ -134,7 +134,7 @@ final class GitlabCollaborators implements Collaborators {
     public Iterator<Collaborator> iterator() {
         LOG.debug(
             "Fetching Gitlab's repo collaborators "
-                + "from [" + this.collaboratorsUri.toString() + "]."
+            + "from [" + this.collaboratorsUri.toString() + "]."
         );
         final Resource response = this.resources.get(this.collaboratorsUri);
         final List<Collaborator> collaborators;
@@ -147,8 +147,9 @@ final class GitlabCollaborators implements Collaborators {
         } else {
             LOG.error(
                 "Unable to fetch Gitlab collaborators"
-                    + " from [" + this.collaboratorsUri.toString() + "],"
-                    + " 200 was expected but we got " + response.statusCode()
+                + " from [" + this.collaboratorsUri.toString() + "],"
+                + " 200 was expected but we got " + response.statusCode() + ". "
+                + "Returning empty list."
             );
             collaborators = List.of();
         }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCommit.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCommit.java
@@ -22,9 +22,7 @@
  */
 package com.selfxdsd.core;
 
-import com.selfxdsd.api.Collaborators;
-import com.selfxdsd.api.Comments;
-import com.selfxdsd.api.Commit;
+import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -109,9 +107,24 @@ final class GitlabCommit implements Commit {
         );
     }
 
+    /**
+     * {@inheritDoc}
+     * <br/>
+     * We have to iterate over Collaborators to get the author's userId,
+     * because it is not contained in the Commit JSON.
+     * More <a href="https://gitlab.com/gitlab-org/gitlab/-/issues/20924">here</a>.
+     */
     @Override
     public String author() {
-        return this.json.getString("author_name");
+        final String authorName = this.json.getString("author_name", "");
+        String author = "";
+        for(final Collaborator collaborator : this.collaborators) {
+            if(authorName.equalsIgnoreCase(collaborator.name())) {
+                author = collaborator.username();
+                break;
+            }
+        }
+        return author;
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCommit.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCommit.java
@@ -22,6 +22,7 @@
  */
 package com.selfxdsd.core;
 
+import com.selfxdsd.api.Collaborators;
 import com.selfxdsd.api.Comments;
 import com.selfxdsd.api.Commit;
 import com.selfxdsd.api.storage.Storage;
@@ -62,6 +63,11 @@ final class GitlabCommit implements Commit {
     private final Storage storage;
 
     /**
+     * Repo Collaborators.
+     */
+    private final Collaborators collaborators;
+
+    /**
      * Gitlab's JSON Resources.
      */
     private final JsonResources resources;
@@ -70,17 +76,20 @@ final class GitlabCommit implements Commit {
      * Ctor.
      * @param commitUri Commit base URI.
      * @param json Json Commit as returned by Gitlab's API.
+     * @param collaborators Repo Collaborators.
      * @param storage Storage.
      * @param resources Gitlab's JSON Resources.
      */
     GitlabCommit(
         final URI commitUri,
         final JsonObject json,
+        final Collaborators collaborators,
         final Storage storage,
         final JsonResources resources
     ) {
         this.commitUri = commitUri;
         this.json = json;
+        this.collaborators = collaborators;
         this.storage = storage;
         this.resources = resources;
     }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCommits.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCommits.java
@@ -22,6 +22,7 @@
  */
 package com.selfxdsd.core;
 
+import com.selfxdsd.api.Collaborators;
 import com.selfxdsd.api.Commit;
 import com.selfxdsd.api.Commits;
 import com.selfxdsd.api.storage.Storage;
@@ -59,6 +60,11 @@ final class GitlabCommits implements Commits {
     private final JsonResources resources;
 
     /**
+     * Repo collaborators.
+     */
+    private final Collaborators collaborators;
+
+    /**
      * Self storage, in case we want to store something.
      */
     private final Storage storage;
@@ -68,15 +74,18 @@ final class GitlabCommits implements Commits {
      *
      * @param resources Gitlab's JSON Resources.
      * @param commitsUri Commits base URI.
+     * @param collaborators Repo collaborators.
      * @param storage Storage.
      */
     GitlabCommits(
         final JsonResources resources,
         final URI commitsUri,
+        final Collaborators collaborators,
         final Storage storage
     ) {
         this.resources = resources;
         this.commitsUri = commitsUri;
+        this.collaborators = collaborators;
         this.storage = storage;
     }
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCommits.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCommits.java
@@ -123,6 +123,7 @@ final class GitlabCommits implements Commits {
             commit = new GitlabCommit(
                 commitUri,
                 jsonObject,
+                this.collaborators,
                 this.storage,
                 this.resources
             );
@@ -146,6 +147,7 @@ final class GitlabCommits implements Commits {
                         + json.getString("short_id")
                 ),
                 json,
+                this.collaborators,
                 this.storage,
                 this.resources
             );

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepo.java
@@ -157,6 +157,7 @@ final class GitlabRepo extends BaseRepo {
         return new GitlabCommits(
             this.resources(),
             uri,
+            this.collaborators(),
             this.storage()
         );
     }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCommitCommentsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCommitCommentsTestCase.java
@@ -22,6 +22,7 @@
  */
 package com.selfxdsd.core;
 
+import com.selfxdsd.api.Collaborators;
 import com.selfxdsd.api.Comment;
 import com.selfxdsd.api.Comments;
 import com.selfxdsd.api.storage.Storage;
@@ -79,6 +80,7 @@ public final class GitlabCommitCommentsTestCase {
         final GitlabCommit commit = new GitlabCommit(
             URI.create("../projects/id/repository/commits/sha"),
             Mockito.mock(JsonObject.class),
+            Mockito.mock(Collaborators.class),
             Mockito.mock(Storage.class),
             new MockJsonResources(
                 req -> {

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCommitTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCommitTestCase.java
@@ -22,6 +22,7 @@
  */
 package com.selfxdsd.core;
 
+import com.selfxdsd.api.Collaborators;
 import com.selfxdsd.api.Commit;
 import com.selfxdsd.api.storage.Storage;
 import org.hamcrest.MatcherAssert;
@@ -50,6 +51,7 @@ public final class GitlabCommitTestCase {
         final Commit commit = new GitlabCommit(
             URI.create("../projects/id/repository/commits/sha"),
             json,
+            Mockito.mock(Collaborators.class),
             Mockito.mock(Storage.class),
             Mockito.mock(JsonResources.class)
         );
@@ -70,6 +72,7 @@ public final class GitlabCommitTestCase {
         final Commit commit = new GitlabCommit(
             URI.create("../projects/id/repository/commits/sha"),
             json,
+            Mockito.mock(Collaborators.class),
             Mockito.mock(Storage.class),
             Mockito.mock(JsonResources.class)
         );
@@ -90,6 +93,7 @@ public final class GitlabCommitTestCase {
         final Commit commit = new GitlabCommit(
             URI.create("../projects/id/repository/commits/sha"),
             json,
+            Mockito.mock(Collaborators.class),
             Mockito.mock(Storage.class),
             Mockito.mock(JsonResources.class)
         );
@@ -107,6 +111,7 @@ public final class GitlabCommitTestCase {
         final Commit commit = new GitlabCommit(
             URI.create("../projects/id/repository/commits/sha"),
             Mockito.mock(JsonObject.class),
+            Mockito.mock(Collaborators.class),
             Mockito.mock(Storage.class),
             Mockito.mock(JsonResources.class)
         );

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCommitTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCommitTestCase.java
@@ -22,8 +22,7 @@
  */
 package com.selfxdsd.core;
 
-import com.selfxdsd.api.Collaborators;
-import com.selfxdsd.api.Commit;
+import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -33,6 +32,8 @@ import org.mockito.Mockito;
 import javax.json.Json;
 import javax.json.JsonObject;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Unit tests for {@link GitlabCommit}.
@@ -62,25 +63,57 @@ public final class GitlabCommitTestCase {
     }
 
     /**
-     * GitlabCommit can return its author.
+     * GitlabCommit can return its author's username by
+     * iterating over Collaborators.
      */
     @Test
-    public void returnsAuthor() {
-        final JsonObject json = Json.createObjectBuilder()
-            .add("author_name", "alilo")
-            .build();
+    public void authorFoundInCollaborators() {
+        final Collaborator mihai = Mockito.mock(Collaborator.class);
+        Mockito.when(mihai.name()).thenReturn("Mihai A.");
+        Mockito.when(mihai.username()).thenReturn("amihaiemil");
+        final Collaborators collaborators = Mockito.mock(Collaborators.class);
+        Mockito.when(collaborators.iterator()).thenReturn(
+            List.of(mihai).iterator()
+        );
         final Commit commit = new GitlabCommit(
             URI.create("../projects/id/repository/commits/sha"),
-            json,
-            Mockito.mock(Collaborators.class),
+            Json.createObjectBuilder()
+                .add("author_name", "Mihai A.")
+                .build(),
+            collaborators,
             Mockito.mock(Storage.class),
             Mockito.mock(JsonResources.class)
         );
         MatcherAssert.assertThat(
             commit.author(),
-            Matchers.equalTo("alilo")
+            Matchers.equalTo("amihaiemil")
         );
     }
+
+    /**
+     * GitlabCommit returns empty string if its author is not found.
+     */
+    @Test
+    public void authorNotFound() {
+        final Collaborators collaborators = Mockito.mock(Collaborators.class);
+        Mockito.when(collaborators.iterator()).thenReturn(
+            new ArrayList<Collaborator>().iterator()
+        );
+        final Commit commit = new GitlabCommit(
+            URI.create("../projects/id/repository/commits/sha"),
+            Json.createObjectBuilder()
+                .add("author_name", "Mihai A.")
+                .build(),
+            collaborators,
+            Mockito.mock(Storage.class),
+            Mockito.mock(JsonResources.class)
+        );
+        MatcherAssert.assertThat(
+            commit.author(),
+            Matchers.equalTo("")
+        );
+    }
+
 
     /**
      * GitlabCommit can return its SHA ref.

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCommitsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCommitsTestCase.java
@@ -22,10 +22,7 @@
  */
 package com.selfxdsd.core;
 
-import com.selfxdsd.api.Commit;
-import com.selfxdsd.api.Commits;
-import com.selfxdsd.api.Repo;
-import com.selfxdsd.api.User;
+import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
 import com.selfxdsd.core.mock.MockJsonResources;
 import org.hamcrest.MatcherAssert;
@@ -54,6 +51,7 @@ public final class GitlabCommitsTestCase {
         final Commits commits = new GitlabCommits(
             Mockito.mock(JsonResources.class),
             URI.create("commits_uri"),
+            Mockito.mock(Collaborators.class),
             Mockito.mock(Storage.class)
         );
         commits.iterator();
@@ -131,6 +129,7 @@ public final class GitlabCommitsTestCase {
                 }
             ),
             URI.create("commits_uri"),
+            Mockito.mock(Collaborators.class),
             Mockito.mock(Storage.class)
         );
         final Commit found = commits.getCommit("bad_ref");
@@ -164,6 +163,7 @@ public final class GitlabCommitsTestCase {
                 }
             ),
             URI.create("commits_uri"),
+            Mockito.mock(Collaborators.class),
             Mockito.mock(Storage.class)
         );
         commits.getCommit("123");
@@ -196,6 +196,7 @@ public final class GitlabCommitsTestCase {
                 }
             ),
             URI.create("commits_uri"),
+            Mockito.mock(Collaborators.class),
             Mockito.mock(Storage.class)
         );
         final Commit found = commits.latest();
@@ -235,6 +236,7 @@ public final class GitlabCommitsTestCase {
                 }
             ),
             URI.create("commits_uri"),
+            Mockito.mock(Collaborators.class),
             Mockito.mock(Storage.class)
         );
         commits.latest();


### PR DESCRIPTION
Fixes #912 

Passes Collaborators down GitlabCommits and GitlabCommit;
GitlabCommit.author() iterates over Collaborators to find the username of the author;
Updated tests;