### PR TITLE
Fixed bug where "_links" is not present in Gitlab org repos json.

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabOrganizationRepos.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabOrganizationRepos.java
@@ -53,7 +53,7 @@ final class GitlabOrganizationRepos implements Repos {
                             final JsonResources resources,
                             final Storage storage) {
         this.uri = URI.create("https://gitlab.com/api/v4/groups/"
-            + organizationId + "/projects?simple=true&owned=true");
+            + organizationId + "/projects?owned=true");
         this.owner = owner;
         this.resources = resources;
         this.storage = storage;

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabOrganizationReposTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabOrganizationReposTestCase.java
@@ -31,7 +31,7 @@ public final class GitlabOrganizationReposTestCase {
             r -> {
                 MatcherAssert.assertThat(r.getUri().toString(),
                     Matchers.equalTo("https://gitlab.com/api/v4/groups"
-                        + "/1/projects?simple=true&owned=true"));
+                        + "/1/projects?owned=true"));
                 return new MockResource(200, Json
                     .createArrayBuilder()
                     .add(Json.createObjectBuilder()


### PR DESCRIPTION
- this key is needed to create GitlabRepo uri: json["_links"]["self"]


--
no bounty needed