### PR TITLE
Commits#latest is now nullable.

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Commits.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Commits.java
@@ -39,7 +39,7 @@ public interface Commits extends Iterable<Commit> {
 
     /**
      * Get the latest Commit (the newest one).
-     * @return Commit.
+     * @return Commit or null if there are no commits.
      */
     Commit latest();
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubCommits.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubCommits.java
@@ -25,6 +25,7 @@ package com.selfxdsd.core;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.util.Iterator;
+import javax.json.JsonArray;
 import javax.json.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -129,15 +130,22 @@ final class GithubCommits implements Commits {
         final Resource resource = this.resources.get(this.commitsUri);
         final Commit latest;
         if (resource.statusCode() == HttpURLConnection.HTTP_OK) {
-            final JsonObject json = resource.asJsonArray().getJsonObject(0);
-            latest = new GithubCommit(
-                URI.create(
-                    this.commitsUri.toString() + "/" + json.getString("sha")
-                ),
-                json,
-                this.storage,
-                this.resources
-            );
+            final JsonArray commits = resource.asJsonArray();
+            if (commits.isEmpty()) {
+                latest = null;
+                LOG.debug("Latest Commit not found, returning null.");
+            } else {
+                final JsonObject json = commits.getJsonObject(0);
+                latest = new GithubCommit(
+                    URI.create(
+                        this.commitsUri.toString()
+                            + "/" + json.getString("sha")
+                    ),
+                    json,
+                    this.storage,
+                    this.resources
+                );
+            }
         } else {
             throw new IllegalStateException(
                 "List of Repo Commits returned " + resource.statusCode()

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubCommitsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubCommitsTestCase.java
@@ -22,18 +22,19 @@
  */
 package com.selfxdsd.core;
 
-import java.net.HttpURLConnection;
-import java.net.URI;
-import javax.json.Json;
-
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.Test;
-import org.mockito.Mockito;
 import com.selfxdsd.api.Commit;
 import com.selfxdsd.api.Commits;
 import com.selfxdsd.api.storage.Storage;
 import com.selfxdsd.core.mock.MockJsonResources;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.json.Json;
+import javax.json.JsonValue;
+import java.net.HttpURLConnection;
+import java.net.URI;
 
 /**
  * Unit tests for {@link GithubCommits}.
@@ -215,6 +216,28 @@ public final class GithubCommitsTestCase {
         MatcherAssert.assertThat(
             found.shaRef(),
             Matchers.equalTo("123")
+        );
+    }
+
+    /**
+     * GithubCommits.latest() can return null if there are no commits.
+     */
+    @Test
+    public void getLatestCommitNull() {
+        final Commits commits = new GithubCommits(
+            new MockJsonResources(
+                req -> new MockJsonResources.MockResource(
+                    HttpURLConnection.HTTP_OK,
+                    JsonValue.EMPTY_JSON_ARRAY
+                )
+            ),
+            URI.create("commits_uri"),
+            Mockito.mock(Storage.class)
+        );
+        final Commit found = commits.latest();
+        MatcherAssert.assertThat(
+            found,
+            Matchers.nullValue()
         );
     }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCommitsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabCommitsTestCase.java
@@ -214,6 +214,29 @@ public final class GitlabCommitsTestCase {
     }
 
     /**
+     * GitlabCommits.latest() can return null if there are no commits.
+     */
+    @Test
+    public void getLatestCommitNull() {
+        final Commits commits = new GitlabCommits(
+            new MockJsonResources(
+                req -> new MockJsonResources.MockResource(
+                    HttpURLConnection.HTTP_OK,
+                    JsonValue.EMPTY_JSON_ARRAY
+                )
+            ),
+            URI.create("commits_uri"),
+            Mockito.mock(Collaborators.class),
+            Mockito.mock(Storage.class)
+        );
+        final Commit found = commits.latest();
+        MatcherAssert.assertThat(
+            found,
+            Matchers.nullValue()
+        );
+    }
+
+    /**
      * GitlabCommits.latest() throws ISE if the HTTP response is not 200 OK.
      */
     @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
Otherwise will throw index out of bounds exception if there are no commits

--
no bounty needed