### PR TITLE
#917 UserProjects.getProjectById() searches in Storage directly

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/PmProjects.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/PmProjects.java
@@ -124,7 +124,7 @@ public final class PmProjects extends BasePaged implements Projects {
                     && owner.provider().name()
                     .equalsIgnoreCase(user.provider().name());
             });
-        return new UserProjects(user, owned);
+        return new UserProjects(user, owned, this.storage);
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/PmProjects.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/PmProjects.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core.projects;
 
 import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Paged;
+import com.selfxdsd.api.storage.Storage;
 import com.selfxdsd.core.BasePaged;
 
 import java.util.Iterator;
@@ -52,27 +53,41 @@ public final class PmProjects extends BasePaged implements Projects {
     private final Supplier<Stream<Project>> projects;
 
     /**
+     * Self Storage.
+     */
+    private final Storage storage;
+
+    /**
      * Constructor.
      * @param pmId ID of the manager.
      * @param projects Projects to choose from.
+     * @param storage Self Storage.
      */
-    public PmProjects(final int pmId,
-                      final Supplier<Stream<Project>> projects) {
-        this(pmId, projects, Page.all());
+    public PmProjects(
+        final int pmId,
+        final Supplier<Stream<Project>> projects,
+        final Storage storage
+    ) {
+        this(pmId, projects, storage, Page.all());
     }
 
     /**
      * Constructor.
      * @param pmId ID of the manager.
      * @param projects Projects to choose from.
+     * @param storage Self Storage.
      * @param page Current Page.
      */
-    public PmProjects(final int pmId,
-                      final Supplier<Stream<Project>> projects,
-                      final Page page) {
+    public PmProjects(
+        final int pmId,
+        final Supplier<Stream<Project>> projects,
+        final Storage storage,
+        final Page page
+    ) {
         super(page, () -> (int) projects.get().count());
         this.pmId = pmId;
         this.projects = projects;
+        this.storage = storage;
     }
 
     @Override
@@ -128,7 +143,7 @@ public final class PmProjects extends BasePaged implements Projects {
 
     @Override
     public Projects page(final Paged.Page page) {
-        return new PmProjects(this.pmId, this.projects, page);
+        return new PmProjects(this.pmId, this.projects, this.storage, page);
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/UserProjects.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/UserProjects.java
@@ -113,7 +113,7 @@ public final class UserProjects extends BasePaged implements Projects {
             .skip((page.getNumber() - 1) * page.getSize())
             .limit(page.getSize())
             .filter(p -> p.projectManager().id() == projectManagerId);
-        return new PmProjects(projectManagerId, assigned, null);
+        return new PmProjects(projectManagerId, assigned, this.storage);
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/UserProjects.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/UserProjects.java
@@ -98,7 +98,7 @@ public final class UserProjects extends BasePaged implements Projects {
             .skip((page.getNumber() - 1) * page.getSize())
             .limit(page.getSize())
             .filter(p -> p.projectManager().id() == projectManagerId);
-        return new PmProjects(projectManagerId, assigned);
+        return new PmProjects(projectManagerId, assigned, null);
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/UserProjects.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/UserProjects.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core.projects;
 
 import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Paged;
+import com.selfxdsd.api.storage.Storage;
 import com.selfxdsd.core.BasePaged;
 
 import java.util.Iterator;
@@ -57,27 +58,41 @@ public final class UserProjects extends BasePaged implements Projects {
     private final Supplier<Stream<Project>> projects;
 
     /**
+     * Self Storage.
+     */
+    private final Storage storage;
+
+    /**
      * Constructor.
      * @param user The user.
      * @param projects The user's projects.
+     * @param storage Self Storage.
      */
-    public UserProjects(final User user,
-                        final Supplier<Stream<Project>> projects) {
-        this(user, projects, Page.all());
+    public UserProjects(
+        final User user,
+        final Supplier<Stream<Project>> projects,
+        final Storage storage
+    ) {
+        this(user, projects, storage, Page.all());
     }
 
     /**
      * Constructor.
      * @param user The user.
      * @param projects The user's projects.
+     * @param storage Self Storage.
      * @param page Current page.
      */
-    public UserProjects(final User user,
-                        final Supplier<Stream<Project>> projects,
-                        final Page page) {
+    public UserProjects(
+        final User user,
+        final Supplier<Stream<Project>> projects,
+        final Storage storage,
+        final Page page
+    ) {
         super(page, () -> (int) projects.get().count());
         this.user = user;
         this.projects = projects;
+        this.storage = storage;
     }
 
     @Override
@@ -130,7 +145,7 @@ public final class UserProjects extends BasePaged implements Projects {
 
     @Override
     public Projects page(final Paged.Page page) {
-        return new UserProjects(this.user, this.projects, page);
+        return new UserProjects(this.user, this.projects, this.storage, page);
     }
 
     @Override

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryProjects.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryProjects.java
@@ -138,7 +138,7 @@ public final class InMemoryProjects extends BasePaged implements Projects{
                     && owner.provider().name()
                     .equals(user.provider().name());
             });
-        return new UserProjects(user, owned);
+        return new UserProjects(user, owned, this.storage);
     }
 
     @Override

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryProjects.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryProjects.java
@@ -121,7 +121,7 @@ public final class InMemoryProjects extends BasePaged implements Projects{
             .skip((page.getNumber() - 1) * page.getSize())
             .limit(page.getSize())
             .filter(p -> p.projectManager().id() == projectManagerId);
-        return new PmProjects(projectManagerId, assigned);
+        return new PmProjects(projectManagerId, assigned, this.storage);
     }
 
     @Override

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/UserProjectsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/UserProjectsTestCase.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core.projects;
 
 import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Paged;
+import com.selfxdsd.api.storage.Storage;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -52,7 +53,9 @@ public final class UserProjectsTestCase {
         list.add(this.projectAssignedTo(3));
         list.add(this.projectAssignedTo(2));
         final Projects projects = new UserProjects(
-            Mockito.mock(User.class), list::stream
+            Mockito.mock(User.class),
+            list::stream,
+            Mockito.mock(Storage.class)
         );
 
         MatcherAssert.assertThat(
@@ -71,7 +74,9 @@ public final class UserProjectsTestCase {
         list.add(Mockito.mock(Project.class));
         list.add(Mockito.mock(Project.class));
         final Projects projects = new UserProjects(
-            Mockito.mock(User.class), list::stream
+            Mockito.mock(User.class),
+            list::stream,
+            Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(projects, Matchers.iterableWithSize(3));
     }
@@ -86,7 +91,9 @@ public final class UserProjectsTestCase {
         list.add(Mockito.mock(Project.class));
         list.add(Mockito.mock(Project.class));
         final Projects projects = new UserProjects(
-            Mockito.mock(User.class), list::stream
+            Mockito.mock(User.class),
+            list::stream,
+            Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(projects.page(new Paged.Page(1, 2)),
             Matchers.iterableWithSize(2));
@@ -101,7 +108,8 @@ public final class UserProjectsTestCase {
     public void ownedByReturnsItself() {
         final Projects projects = new UserProjects(
             this.mockUser("mihai", "github"),
-            Stream::empty
+            Stream::empty,
+            Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(
             projects.ownedBy(this.mockUser("mihai", "github")),
@@ -117,7 +125,8 @@ public final class UserProjectsTestCase {
     public void ownedByComplainsOnDifferendUser() {
         final Projects projects = new UserProjects(
             this.mockUser("mihai", "github"),
-            Stream::empty
+            Stream::empty,
+            Mockito.mock(Storage.class)
         );
         projects.ownedBy(this.mockUser("vlad", "github"));
     }
@@ -132,7 +141,8 @@ public final class UserProjectsTestCase {
             () -> List.of(
                 mockProject("mihai/test", "github"),
                 mockProject("mihai/test2", "github")
-            ).stream()
+            ).stream(),
+            Mockito.mock(Storage.class)
         );
         final Project found = projects.getProjectById("mihai/test", "github");
         MatcherAssert.assertThat(
@@ -157,7 +167,8 @@ public final class UserProjectsTestCase {
                 mockProject("mihai/test2", "github"),
                 mockProject("mihai/test3", "github"),
                 mockProject("mihai/test4", "github")
-            ).stream()
+            ).stream(),
+            Mockito.mock(Storage.class)
         );
         final Project found = projects
             .page(new Paged.Page(2, 2))
@@ -178,7 +189,9 @@ public final class UserProjectsTestCase {
     @Test
     public void projectByIdNotFound() {
         final Projects projects = new UserProjects(
-            this.mockUser("mihai", "github"), Stream::empty
+            this.mockUser("mihai", "github"),
+            Stream::empty,
+            Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(
             projects.getProjectById("mihai/test", "github"),
@@ -193,12 +206,14 @@ public final class UserProjectsTestCase {
     @Test
     public void existingProjectByIdNotFoundInPage() {
         final Projects projects = new UserProjects(
-            this.mockUser("mihai", "github"), () -> List.of(
-            mockProject("mihai/test", "github"),
-            mockProject("mihai/test2", "github"),
-            mockProject("mihai/test3", "github"),
-            mockProject("mihai/test4", "github")
-        ).stream()
+            this.mockUser("mihai", "github"),
+            () -> List.of(
+                mockProject("mihai/test", "github"),
+                mockProject("mihai/test2", "github"),
+                mockProject("mihai/test3", "github"),
+                mockProject("mihai/test4", "github")
+            ).stream(),
+            Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(
             projects
@@ -221,7 +236,8 @@ public final class UserProjectsTestCase {
                 mockProject("mihai/test2", "github"),
                 mockProject("mihai/test3", "github"),
                 mockProject("mihai/test4", "github")
-            ).stream()
+            ).stream(),
+            Mockito.mock(Storage.class)
         );
         final Project toRemove = mockProject("mihai/test", "github");
         final Repo repo = Mockito.mock(Repo.class);
@@ -245,7 +261,8 @@ public final class UserProjectsTestCase {
                 mockProject("mihai/test2", "github"),
                 mockProject("mihai/test3", "github"),
                 mockProject("mihai/test4", "github")
-            ).stream()
+            ).stream(),
+            Mockito.mock(Storage.class)
         );
         final Project toRemove = mockProject("mihai/test", "github");
         final Repo repo = Mockito.mock(Repo.class);

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/UserProjectsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/UserProjectsTestCase.java
@@ -136,89 +136,94 @@ public final class UserProjectsTestCase {
      */
     @Test
     public void projectByIdFound() {
+        final User user = this.mockUser("mihai", "github");
+
+        final Project project = Mockito.mock(Project.class);
+        Mockito.when(project.owner()).thenReturn(user);
+        final Projects all = Mockito.mock(Projects.class);
+        Mockito.when(
+            all.getProjectById("mihai/test", "github")
+        ).thenReturn(project);
+
+        final Storage storage = Mockito.mock(Storage.class);
+        Mockito.when(storage.projects()).thenReturn(all);
+
         final Projects projects = new UserProjects(
-            this.mockUser("mihai", "github"),
+            user,
             () -> List.of(
                 mockProject("mihai/test", "github"),
                 mockProject("mihai/test2", "github")
             ).stream(),
-            Mockito.mock(Storage.class)
+            storage
         );
         final Project found = projects.getProjectById("mihai/test", "github");
         MatcherAssert.assertThat(
-            found.repoFullName(),
-            Matchers.equalTo("mihai/test")
-        );
-        MatcherAssert.assertThat(
-            found.provider(),
-            Matchers.equalTo("github")
+            found,
+            Matchers.is(project)
         );
     }
 
     /**
-     * Should find a project by it's id in a page.
+     * A Project is found but it belongs to another User so the
+     * method should return null.
      */
     @Test
-    public void projectByIdFoundInPage() {
+    public void projectByIdFoundButHasOtherOwner() {
+        final User mihai = this.mockUser("mihai", "github");
+        final User vlad = this.mockUser("vlad", "github");
+
+        final Project project = Mockito.mock(Project.class);
+        Mockito.when(project.owner()).thenReturn(vlad);
+        final Projects all = Mockito.mock(Projects.class);
+        Mockito.when(
+            all.getProjectById("vlad/test", "github")
+        ).thenReturn(project);
+
+        final Storage storage = Mockito.mock(Storage.class);
+        Mockito.when(storage.projects()).thenReturn(all);
+
         final Projects projects = new UserProjects(
-            this.mockUser("mihai", "github"),
+            mihai,
             () -> List.of(
                 mockProject("mihai/test", "github"),
-                mockProject("mihai/test2", "github"),
-                mockProject("mihai/test3", "github"),
-                mockProject("mihai/test4", "github")
+                mockProject("mihai/test2", "github")
             ).stream(),
-            Mockito.mock(Storage.class)
+            storage
         );
-        final Project found = projects
-            .page(new Paged.Page(2, 2))
-            .getProjectById("mihai/test3", "github");
+        final Project found = projects.getProjectById("vlad/test", "github");
         MatcherAssert.assertThat(
-            found.repoFullName(),
-            Matchers.equalTo("mihai/test3")
-        );
-        MatcherAssert.assertThat(
-            found.provider(),
-            Matchers.equalTo("github")
+            found,
+            Matchers.nullValue()
         );
     }
+
 
     /**
      * Should return null is project is not found by id.
      */
     @Test
     public void projectByIdNotFound() {
-        final Projects projects = new UserProjects(
-            this.mockUser("mihai", "github"),
-            Stream::empty,
-            Mockito.mock(Storage.class)
-        );
-        MatcherAssert.assertThat(
-            projects.getProjectById("mihai/test", "github"),
-            Matchers.nullValue()
-        );
-    }
+        final User user = this.mockUser("mihai", "github");
 
-    /**
-     * Should return null if project is not found by id in the page, even
-     * though it exists overall.
-     */
-    @Test
-    public void existingProjectByIdNotFoundInPage() {
+        final Projects all = Mockito.mock(Projects.class);
+        Mockito.when(
+            all.getProjectById("mihai/test", "github")
+        ).thenReturn(null);
+
+        final Storage storage = Mockito.mock(Storage.class);
+        Mockito.when(storage.projects()).thenReturn(all);
+
         final Projects projects = new UserProjects(
-            this.mockUser("mihai", "github"),
+            user,
             () -> List.of(
                 mockProject("mihai/test", "github"),
-                mockProject("mihai/test2", "github"),
-                mockProject("mihai/test3", "github"),
-                mockProject("mihai/test4", "github")
+                mockProject("mihai/test2", "github")
             ).stream(),
-            Mockito.mock(Storage.class)
+            storage
         );
+        final Project found = projects.getProjectById("mihai/test", "github");
         MatcherAssert.assertThat(
-            projects
-                .page(new Paged.Page(2, 2))
-                .getProjectById("mihai/test", "github"),
+            found,
             Matchers.nullValue()
         );
     }


### PR DESCRIPTION
Fixes #917 

* Both UserProjects and PmProjects now encapsulate the Storage
* UserProjects.getProjectById() searches in the storage directly
* updated unit tests