### PR TITLE
Fixed organization repo owner filter.

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabOrganizationRepos.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabOrganizationRepos.java
@@ -53,7 +53,7 @@ final class GitlabOrganizationRepos implements Repos {
                             final JsonResources resources,
                             final Storage storage) {
         this.uri = URI.create("https://gitlab.com/api/v4/groups/"
-            + organizationId + "/projects?owned=true");
+            + organizationId + "/projects?min_access_level=40");
         this.owner = owner;
         this.resources = resources;
         this.storage = storage;

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabOrganizationReposTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabOrganizationReposTestCase.java
@@ -31,7 +31,7 @@ public final class GitlabOrganizationReposTestCase {
             r -> {
                 MatcherAssert.assertThat(r.getUri().toString(),
                     Matchers.equalTo("https://gitlab.com/api/v4/groups"
-                        + "/1/projects?owned=true"));
+                        + "/1/projects?min_access_level=40"));
                 return new MockResource(200, Json
                     .createArrayBuilder()
                     .add(Json.createObjectBuilder()


### PR DESCRIPTION
Passing `owned = true` as parameter won't stop to display repos to all org members.
Replacing it with `min_access_level = 40` (Maintainer or Owner) fixes it.

https://docs.gitlab.com/ee/api/members.html#valid-access-levels

--
no bounty