### PR TITLE
#952 GithubCommit.author() can be missing

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubCommit.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubCommit.java
@@ -92,7 +92,14 @@ final class GithubCommit implements Commit {
 
     @Override
     public String author() {
-        return this.json.getJsonObject("author").getString("login");
+        final String username;
+        final JsonObject author = this.json.getJsonObject("author");
+        if(author == null) {
+            username = "";
+        } else {
+            username = author.getString("login", "");
+        }
+        return username;
     }
 
     @Override

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubCommitTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubCommitTestCase.java
@@ -83,6 +83,52 @@ public final class GithubCommitTestCase {
     }
 
     /**
+     * GithubCommit can return an empty author is the 'author'
+     * JsonObject is missing from the Commit json.
+     */
+    @Test
+    public void returnsEmptyAuthorOnMissingAuthorJsonObject() {
+        final JsonObject json = Json.createObjectBuilder()
+            .add("sha", "123ref")
+            .build();
+        final Commit commit = new GithubCommit(
+            URI.create("localhost:8080/repos/mihai/test/commits/123ref"),
+            json,
+            Mockito.mock(Storage.class),
+            Mockito.mock(JsonResources.class)
+        );
+        MatcherAssert.assertThat(
+            commit.author(),
+            Matchers.equalTo("")
+        );
+    }
+
+    /**
+     * GithubCommit can return an empty author is the 'author'
+     * JsonObject is present in the Commit json BUT it does not
+     * have the 'login' attribute.
+     */
+    @Test
+    public void returnsEmptyAuthorOnMissingLoginAttribute() {
+        final JsonObject json = Json.createObjectBuilder()
+            .add("sha", "123ref")
+            .add(
+                "author",
+                Json.createObjectBuilder().add("name", "Mihai A.")
+            ).build();
+        final Commit commit = new GithubCommit(
+            URI.create("localhost:8080/repos/mihai/test/commits/123ref"),
+            json,
+            Mockito.mock(Storage.class),
+            Mockito.mock(JsonResources.class)
+        );
+        MatcherAssert.assertThat(
+            commit.author(),
+            Matchers.equalTo("")
+        );
+    }
+
+    /**
      * GithubCommit can return its SHA ref.
      */
     @Test


### PR DESCRIPTION
Fixes #952 

Covered the case when the commit author is missing in Github. Will return an empty username.