### PR TITLE
#988 PayoutMethod.remove() implemented and tested

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/PayoutMethod.java
+++ b/self-api/src/main/java/com/selfxdsd/api/PayoutMethod.java
@@ -66,6 +66,12 @@ public interface PayoutMethod {
     JsonObject json();
 
     /**
+     * Remove this PayoutMethod.
+     * @return True if succeeded, false otherwise.
+     */
+    boolean remove();
+
+    /**
      * Possible payout methods.
      */
     class Type {

--- a/self-api/src/main/java/com/selfxdsd/api/PayoutMethods.java
+++ b/self-api/src/main/java/com/selfxdsd/api/PayoutMethods.java
@@ -28,9 +28,6 @@ package com.selfxdsd.api;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.22
- * @todo #988:60min Implement method PayoutMethod.remove() which
- *  will remove the PayoutMethod from Stripe and call this.storage
- *  .payoutMethods().remove(this) to remove it from the storage.
  */
 public interface PayoutMethods extends Iterable<PayoutMethod> {
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contributors/ContributorPayoutMethods.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contributors/ContributorPayoutMethods.java
@@ -107,8 +107,7 @@ public final class ContributorPayoutMethods implements PayoutMethods {
     @Override
     public boolean remove(final PayoutMethod payoutMethod) {
         if(this.contributor.equals(payoutMethod.contributor())) {
-            final boolean removed = this.storage.payoutMethods()
-                .remove(payoutMethod);
+            final boolean removed = payoutMethod.remove();
             if(removed) {
                 this.payoutMethods.remove(payoutMethod);
             }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contributors/ContributorPayoutMethodsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contributors/ContributorPayoutMethodsTestCase.java
@@ -250,19 +250,14 @@ public final class ContributorPayoutMethodsTestCase {
         final PayoutMethod paypal = Mockito.mock(PayoutMethod.class);
         Mockito.when(paypal.type()).thenReturn(PayoutMethod.Type.PAYPAL);
         final PayoutMethod stripe = Mockito.mock(PayoutMethod.class);
-        Mockito.when(paypal.type()).thenReturn(PayoutMethod.Type.STRIPE);
+        Mockito.when(stripe.type()).thenReturn(PayoutMethod.Type.STRIPE);
         Mockito.when(stripe.contributor()).thenReturn(contributor);
-
-        final PayoutMethods all = Mockito.mock(PayoutMethods.class);
-        Mockito.when(all.remove(stripe)).thenReturn(true);
-
-        final Storage storage = Mockito.mock(Storage.class);
-        Mockito.when(storage.payoutMethods()).thenReturn(all);
+        Mockito.when(stripe.remove()).thenReturn(Boolean.TRUE);
 
         final PayoutMethods methods = new ContributorPayoutMethods(
             contributor,
             Arrays.asList(paypal, stripe),
-            storage
+            Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(
             methods,
@@ -278,7 +273,6 @@ public final class ContributorPayoutMethodsTestCase {
             methods,
             Matchers.iterableWithSize(1)
         );
-        Mockito.verify(all, Mockito.times(1)).remove(stripe);
     }
 
     /**

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contributors/StripePayoutMethodTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contributors/StripePayoutMethodTestCase.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core.contributors;
 
 import com.selfxdsd.api.Contributor;
 import com.selfxdsd.api.PayoutMethod;
+import com.selfxdsd.api.storage.Storage;
 import com.selfxdsd.core.Env;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -47,7 +48,8 @@ public final class StripePayoutMethodTestCase {
         final Contributor owner = Mockito.mock(Contributor.class);
         final PayoutMethod method = new StripePayoutMethod(
             owner,
-            "acct_001"
+            "acct_001",
+            Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(
             method.contributor(),
@@ -62,7 +64,8 @@ public final class StripePayoutMethodTestCase {
     public void returnsType() {
         final PayoutMethod method = new StripePayoutMethod(
             Mockito.mock(Contributor.class),
-            "acct_001"
+            "acct_001",
+            Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(
             method.type(),
@@ -77,7 +80,8 @@ public final class StripePayoutMethodTestCase {
     public void returnsIdentifier() {
         final PayoutMethod method = new StripePayoutMethod(
             Mockito.mock(Contributor.class),
-            "acct_001"
+            "acct_001",
+            Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(
             method.identifier(),
@@ -93,7 +97,8 @@ public final class StripePayoutMethodTestCase {
     public void jsonComplainsOnMissingApiKey() {
         final PayoutMethod method = new StripePayoutMethod(
             Mockito.mock(Contributor.class),
-            "acct_001"
+            "acct_001",
+            Mockito.mock(Storage.class)
         );
 
         try {
@@ -120,11 +125,39 @@ public final class StripePayoutMethodTestCase {
     public void billingInfoComplainsOnMissingKey() {
         final PayoutMethod method = new StripePayoutMethod(
             Mockito.mock(Contributor.class),
-            "acct_001"
+            "acct_001",
+            Mockito.mock(Storage.class)
         );
 
         try {
             method.billingInfo();
+            Assert.fail("IllegalStateException was expected.");
+        } catch (final IllegalStateException ex) {
+            MatcherAssert.assertThat(
+                ex.getMessage(),
+                Matchers.equalTo(
+                "Please specify the "
+                    + Env.STRIPE_API_TOKEN
+                    + " Environment Variable!"
+                )
+            );
+        }
+    }
+
+    /**
+     * StoredContributor.remove() should throw an ISE
+     * if the Stripe API token is not set.
+     */
+    @Test
+    public void removeComplainsOnMissingKey() {
+        final PayoutMethod method = new StripePayoutMethod(
+            Mockito.mock(Contributor.class),
+            "acct_001",
+            Mockito.mock(Storage.class)
+        );
+
+        try {
+            method.remove();
             Assert.fail("IllegalStateException was expected.");
         } catch (final IllegalStateException ex) {
             MatcherAssert.assertThat(

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryPayoutMethods.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryPayoutMethods.java
@@ -69,7 +69,8 @@ public final class InMemoryPayoutMethods implements PayoutMethods {
     ) {
         final PayoutMethod method = new StripePayoutMethod(
             contributor,
-            identifier
+            identifier,
+            this.storage
         );
         this.payoutMethods.put(
             new PayoutMethodKey(


### PR DESCRIPTION
PR for #988 

StripePayoutMethod.remove() implemented and tested;
StripePayoutMethod takes Storage as ctor argument;
ContributorPayoutMethods.remove(PayoutMethod) uses PayoutMethod.remove();