### PR TITLE
#998 Invoice.billedByCountry,billedToCountry,eurToRon + tests

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Invoice.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Invoice.java
@@ -67,6 +67,19 @@ public interface Invoice {
     String billedTo();
 
     /**
+     * Country of the Contributor (who billed this Invoice).
+     * @return String.
+     */
+    String billedByCountry();
+
+    /**
+     * Country of the Client (who received this Invoice).
+     * Country of the Client (who received this Invoice).
+     * @return String.
+     */
+    String billedToCountry();
+
+    /**
      * Tasked invoiced here.
      * @return InvoicedTasks.
      */
@@ -90,6 +103,12 @@ public interface Invoice {
      * @return BigDecimal.
      */
     BigDecimal commission();
+
+    /**
+     * EUR to RON exchange rage (e.g. if 487, then it means 1 EUR = 4,87 RON).
+     * @return BigDecimal.
+     */
+    BigDecimal eurToRon();
 
     /**
      * An invoice is active until payment is done.

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/StoredInvoice.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/StoredInvoice.java
@@ -2,6 +2,7 @@ package com.selfxdsd.core.contracts.invoices;
 
 import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
+import com.selfxdsd.core.projects.XmlBnr;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
@@ -65,6 +66,21 @@ public final class StoredInvoice implements Invoice {
     private final String billedTo;
 
     /**
+     * Country of the Contributor (who emitted this Invoice).
+     */
+    private final String billedByCountry;
+
+    /**
+     * Country of the Client (who received this Invoice).
+     */
+    private final String billedToCountry;
+
+    /**
+     * EUR to RON exchange rate (e.g. if 487, it means 1 EUR = 4,87 RON).
+     */
+    private final BigDecimal eurToRon;
+
+    /**
      * Self storage context.
      */
     private final Storage storage;
@@ -78,7 +94,11 @@ public final class StoredInvoice implements Invoice {
      * @param transactionId The payment's transaction ID.
      * @param billedBy Who emitted the Invoice.
      * @param billedTo Who pays it.
+     * @param billedByCountry Country of the Contributor.
+     * @param billedToCountry Country of the Client.
+     * @param eurToRon EUR to RON exchange rate.
      * @param storage Self storage context.
+     * @checkstyle ParameterNumber (50 lines)
      */
     public StoredInvoice(
         final int id,
@@ -88,6 +108,9 @@ public final class StoredInvoice implements Invoice {
         final String transactionId,
         final String billedBy,
         final String billedTo,
+        final String billedByCountry,
+        final String billedToCountry,
+        final BigDecimal eurToRon,
         final Storage storage
     ) {
         this.id = id;
@@ -97,6 +120,9 @@ public final class StoredInvoice implements Invoice {
         this.transactionId = transactionId;
         this.billedBy = billedBy;
         this.billedTo = billedTo;
+        this.billedByCountry = billedByCountry;
+        this.billedToCountry = billedToCountry;
+        this.eurToRon = eurToRon;
         this.storage = storage;
     }
 
@@ -172,6 +198,30 @@ public final class StoredInvoice implements Invoice {
             billedTo = this.contract.project().billingInfo().toString();
         }
         return billedTo;
+    }
+
+    @Override
+    public String billedByCountry() {
+        final String billedByCountry;
+        if(this.billedByCountry != null && !this.billedByCountry.isEmpty()) {
+            billedByCountry = this.billedByCountry;
+        } else {
+            billedByCountry = this.contract.contributor().billingInfo()
+                .country();
+        }
+        return billedByCountry;
+    }
+
+    @Override
+    public String billedToCountry() {
+        final String billedToCountry;
+        if(this.billedToCountry != null && !this.billedToCountry.isEmpty()) {
+            billedToCountry = this.billedToCountry;
+        } else {
+            billedToCountry = this.contract.project().billingInfo().country();
+        }
+        return billedToCountry;
+
     }
 
     @Override
@@ -307,6 +357,17 @@ public final class StoredInvoice implements Invoice {
             commission = commission.add(task.commission());
         }
         return commission;
+    }
+
+    @Override
+    public BigDecimal eurToRon() {
+        final BigDecimal eurToRon;
+        if(!this.eurToRon.equals(BigDecimal.valueOf(0))) {
+            eurToRon = this.eurToRon;
+        } else {
+            eurToRon = new XmlBnr().euroToRon();
+        }
+        return eurToRon;
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
@@ -143,6 +143,9 @@ public final class FakeWallet implements Wallet {
                     "fake_payment_" + uuid,
                     invoice.billedBy(),
                     invoice.billedTo(),
+                    "FK Country",
+                    "FK Country",
+                    BigDecimal.valueOf(0),
                     this.storage
                 ),
                 BigDecimal.valueOf(0),

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
@@ -220,9 +220,10 @@ public final class StripeWallet implements Wallet {
                 );
             }
 
+            final BillingInfo contributorBilling = payoutMethod.billingInfo();
             final BigDecimal vat = this.calculateVat(
                 invoice.commission(),
-                payoutMethod.billingInfo()
+                contributorBilling
             );
             final PaymentIntent paymentIntent = PaymentIntent
                 .create(
@@ -256,6 +257,7 @@ public final class StripeWallet implements Wallet {
                 final LocalDateTime paymentDate = LocalDateTime
                     .ofEpochSecond(paymentIntent.getCreated(),
                         0, OffsetDateTime.now().getOffset());
+                final BigDecimal eurToRon = new XmlBnr().euroToRon();
                 this.storage.invoices()
                     .registerAsPaid(
                         new StoredInvoice(
@@ -266,10 +268,13 @@ public final class StripeWallet implements Wallet {
                             paymentIntent.getId(),
                             invoice.billedBy(),
                             invoice.billedTo(),
+                            contributorBilling.country(),
+                            contract.project().billingInfo().country(),
+                            eurToRon,
                             this.storage
                         ),
                         vat,
-                        new XmlBnr().euroToRon()
+                        eurToRon
                     );
             } else {
                 LOG.error("[STRIPE] PaymentIntent status: " + status);

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/XmlBnr.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/XmlBnr.java
@@ -47,7 +47,7 @@ import java.net.http.HttpResponse;
  * @checkstyle ReturnCount (200 lines)
  * @checkstyle IllegalCatch (200 lines)
  */
-final class XmlBnr implements Bnr {
+public final class XmlBnr implements Bnr {
 
     /**
      * Logger.
@@ -64,7 +64,7 @@ final class XmlBnr implements Bnr {
     /**
      * Ctor. Uses BNR's real API by default.
      */
-    XmlBnr() {
+    public XmlBnr() {
         this(URI.create("https://www.bnr.ro/nbrfxrates.xml"));
     }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/StoredInvoiceTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/StoredInvoiceTestCase.java
@@ -46,6 +46,9 @@ public final class StoredInvoiceTestCase {
             "transacetionId123",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             Mockito.mock(Storage.class)
         );
         assertThat(invoice.invoiceId(), is(1));
@@ -65,6 +68,9 @@ public final class StoredInvoiceTestCase {
             "transacetionId123",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             Mockito.mock(Storage.class)
         );
         assertThat(invoice.contract(), is(contract));
@@ -84,6 +90,9 @@ public final class StoredInvoiceTestCase {
             "transactionID",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             storage
         );
         final InvoicedTasks all = Mockito.mock(InvoicedTasks.class);
@@ -122,6 +131,9 @@ public final class StoredInvoiceTestCase {
             "transactionID",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             storage
         );
         final InvoicedTasks all = Mockito.mock(InvoicedTasks.class);
@@ -163,6 +175,9 @@ public final class StoredInvoiceTestCase {
             "transactionID",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             storage
         );
         final InvoicedTasks all = Mockito.mock(InvoicedTasks.class);
@@ -204,6 +219,9 @@ public final class StoredInvoiceTestCase {
             "transactionID",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             storage
         );
         final InvoicedTasks all = Mockito.mock(InvoicedTasks.class);
@@ -245,6 +263,9 @@ public final class StoredInvoiceTestCase {
             "transacetionId123",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(
@@ -268,6 +289,9 @@ public final class StoredInvoiceTestCase {
             "transactionId",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             storage
         );
         MatcherAssert.assertThat(
@@ -290,6 +314,9 @@ public final class StoredInvoiceTestCase {
             "transactionId123",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             mock(Storage.class)
         );
         MatcherAssert.assertThat(
@@ -321,6 +348,9 @@ public final class StoredInvoiceTestCase {
             "transacetionId123",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             Mockito.mock(Storage.class)
         );
 
@@ -361,6 +391,9 @@ public final class StoredInvoiceTestCase {
             "transactionId123",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             Mockito.mock(Storage.class)
         );
 
@@ -414,6 +447,9 @@ public final class StoredInvoiceTestCase {
             null,
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             storage
         );
 
@@ -449,6 +485,9 @@ public final class StoredInvoiceTestCase {
             "transacetionId123",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             Mockito.mock(Storage.class)
         );
         final Invoice invoiceTwo = new StoredInvoice(
@@ -459,6 +498,9 @@ public final class StoredInvoiceTestCase {
             "transacetionId123",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(invoice, Matchers.equalTo(invoiceTwo));
@@ -477,6 +519,9 @@ public final class StoredInvoiceTestCase {
             "transacetionId123",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             Mockito.mock(Storage.class)
         );
         final Invoice invoiceTwo = new StoredInvoice(
@@ -487,6 +532,9 @@ public final class StoredInvoiceTestCase {
             "transacetionId123",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(invoice.hashCode(),
@@ -508,11 +556,40 @@ public final class StoredInvoiceTestCase {
             "transacetionId123",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(
             invoice.billedBy(),
             Matchers.equalTo("mihai")
+        );
+    }
+
+    /**
+     * If the billedByCountry attribute is set in the constructor
+     * (not null and not empty), that's the value that should be
+     * returned.
+     */
+    @Test
+    public void returnsSetBilledByCountry() {
+        final Invoice invoice = new StoredInvoice(
+            1,
+            Mockito.mock(Contract.class),
+            LocalDateTime.now(),
+            LocalDateTime.now(),
+            "transacetionId123",
+            "mihai",
+            "vlad",
+            "BG",
+            "RO",
+            BigDecimal.valueOf(487),
+            Mockito.mock(Storage.class)
+        );
+        MatcherAssert.assertThat(
+            invoice.billedByCountry(),
+            Matchers.equalTo("BG")
         );
     }
 
@@ -531,11 +608,91 @@ public final class StoredInvoiceTestCase {
             "transacetionId123",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(
             invoice.billedTo(),
             Matchers.equalTo("vlad")
+        );
+    }
+
+    /**
+     * If the billedToCountry attribute is set in the constructor
+     * (not null and not empty), that's the value that should be
+     * returned.
+     */
+    @Test
+    public void returnsSetBilledToCountry() {
+        final Invoice invoice = new StoredInvoice(
+            1,
+            Mockito.mock(Contract.class),
+            LocalDateTime.now(),
+            LocalDateTime.now(),
+            "transacetionId123",
+            "mihai",
+            "vlad",
+            "RO",
+            "DE",
+            BigDecimal.valueOf(487),
+            Mockito.mock(Storage.class)
+        );
+        MatcherAssert.assertThat(
+            invoice.billedToCountry(),
+            Matchers.equalTo("DE")
+        );
+    }
+
+    /**
+     * If the eurToRon attribute is set in the constructor
+     * (not 0), that's the value that should be
+     * returned.
+     */
+    @Test
+    public void returnsSetEurToRon() {
+        final Invoice invoice = new StoredInvoice(
+            1,
+            Mockito.mock(Contract.class),
+            LocalDateTime.now(),
+            LocalDateTime.now(),
+            "transacetionId123",
+            "mihai",
+            "vlad",
+            "RO",
+            "DE",
+            BigDecimal.valueOf(300),
+            Mockito.mock(Storage.class)
+        );
+        MatcherAssert.assertThat(
+            invoice.eurToRon(),
+            Matchers.equalTo(BigDecimal.valueOf(300))
+        );
+    }
+
+    /**
+     * If the eurToRon attribute is NOT set in the constructor
+     * (value 0), then it will be read from BNR (via XmlBnr).
+     */
+    @Test
+    public void returnsBnrEurToRon() {
+        final Invoice invoice = new StoredInvoice(
+            1,
+            Mockito.mock(Contract.class),
+            LocalDateTime.now(),
+            LocalDateTime.now(),
+            "transacetionId123",
+            "mihai",
+            "vlad",
+            null,
+            null,
+            BigDecimal.valueOf(0),
+            Mockito.mock(Storage.class)
+        );
+        MatcherAssert.assertThat(
+            invoice.eurToRon(),
+            Matchers.greaterThanOrEqualTo(BigDecimal.valueOf(450))
         );
     }
 
@@ -560,11 +717,46 @@ public final class StoredInvoiceTestCase {
             "transacetionId123",
             null,
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(
             invoice.billedBy(),
             Matchers.equalTo("Contributor LLC")
+        );
+    }
+
+    /**
+     * If the billedByCountry is not given as ctor parameter (set to null),
+     * then it should be read from the Contract.
+     */
+    @Test
+    public void returnsContractBilledByCountry() {
+        final BillingInfo info = Mockito.mock(BillingInfo.class);
+        Mockito.when(info.country()).thenReturn("UK");
+        final Contributor contributor = Mockito.mock(Contributor.class);
+        Mockito.when(contributor.billingInfo()).thenReturn(info);
+        final Contract contract = Mockito.mock(Contract.class);
+        Mockito.when(contract.contributor()).thenReturn(contributor);
+
+        final Invoice invoice = new StoredInvoice(
+            1,
+            contract,
+            LocalDateTime.now(),
+            LocalDateTime.now(),
+            "transacetionId123",
+            null,
+            "vlad",
+            null,
+            null,
+            BigDecimal.valueOf(0),
+            Mockito.mock(Storage.class)
+        );
+        MatcherAssert.assertThat(
+            invoice.billedByCountry(),
+            Matchers.equalTo("UK")
         );
     }
 
@@ -589,11 +781,46 @@ public final class StoredInvoiceTestCase {
             "transacetionId123",
             "mihai",
             null,
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             Mockito.mock(Storage.class)
         );
         MatcherAssert.assertThat(
             invoice.billedTo(),
             Matchers.equalTo("Project LLC")
+        );
+    }
+
+    /**
+     * If the billedToCountry is not given as ctor parameter (set to null),
+     * then it should be read from the Contract.
+     */
+    @Test
+    public void returnsContractBilledToCountry() {
+        final BillingInfo info = Mockito.mock(BillingInfo.class);
+        Mockito.when(info.country()).thenReturn("DK");
+        final Project project = Mockito.mock(Project.class);
+        Mockito.when(project.billingInfo()).thenReturn(info);
+        final Contract contract = Mockito.mock(Contract.class);
+        Mockito.when(contract.project()).thenReturn(project);
+
+        final Invoice invoice = new StoredInvoice(
+            1,
+            contract,
+            LocalDateTime.now(),
+            LocalDateTime.now(),
+            "transacetionId123",
+            "mihai",
+            null,
+            null,
+            null,
+            BigDecimal.valueOf(0),
+            Mockito.mock(Storage.class)
+        );
+        MatcherAssert.assertThat(
+            invoice.billedToCountry(),
+            Matchers.equalTo("DK")
         );
     }
 
@@ -616,6 +843,9 @@ public final class StoredInvoiceTestCase {
             null,
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             storage
         );
         MatcherAssert.assertThat(
@@ -644,6 +874,9 @@ public final class StoredInvoiceTestCase {
             "fake_payment_123",
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             storage
         );
         MatcherAssert.assertThat(
@@ -678,6 +911,9 @@ public final class StoredInvoiceTestCase {
             transactionId,
             "mihai",
             "vlad",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             storage
         );
         MatcherAssert.assertThat(
@@ -733,6 +969,9 @@ public final class StoredInvoiceTestCase {
             "transaction123",
             "mihai",
             "contributro",
+            "RO",
+            "RO",
+            BigDecimal.valueOf(487),
             storage
         );
         storage

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryInvoices.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryInvoices.java
@@ -79,6 +79,9 @@ public final class InMemoryInvoices implements Invoices {
             null,
             null,
             null,
+            null,
+            null,
+            BigDecimal.valueOf(0),
             this.storage
         );
         this.invoices.put(created.invoiceId(), created);

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/StripeWalletITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/StripeWalletITCase.java
@@ -90,6 +90,13 @@ public final class StripeWalletITCase {
                 .thenReturn(BigDecimal.valueOf(108 * 100));
 
             final Contract contract = Mockito.mock(Contract.class);
+
+            final Project project = Mockito.mock(Project.class);
+            final BillingInfo projectInfo = Mockito.mock(BillingInfo.class);
+            Mockito.when(projectInfo.country()).thenReturn("BG");
+            Mockito.when(project.billingInfo()).thenReturn(projectInfo);
+            Mockito.when(contract.project()).thenReturn(project);
+
             final Contributor contributor = Mockito.mock(Contributor.class);
             Mockito.when(contract.contributor()).thenReturn(contributor);
             Mockito.when(invoice.contract()).thenReturn(contract);
@@ -115,7 +122,6 @@ public final class StripeWalletITCase {
             final Invoices invoices = Mockito.mock(Invoices.class);
             Mockito.when(storage.invoices()).thenReturn(invoices);
 
-            final Project project = Mockito.mock(Project.class);
             final Wallets allWallets = Mockito.mock(Wallets.class);
             final Wallets ofProject = Mockito.mock(Wallets.class);
 


### PR DESCRIPTION
Fixes #998 

Added Invoice.billedByCountry,billedToCountry and eurToRon;
If they are not set, they will be read from the Contract and BNR respectively;
Added tests;

Updated StripeWallet.pay(...) to set these values when registering the Invoice as paid.

