### PR TITLE
#1004 Wallets.remove(Wallet) implemented and tested

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Wallet.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Wallet.java
@@ -120,6 +120,11 @@ public interface Wallet {
     BillingInfo billingInfo();
 
     /**
+     * Remove this Wallet.
+     * @return True if removed, false otherwise.
+     */
+    boolean remove();
+    /**
      * Possible wallet types.
      */
     class Type {

--- a/self-api/src/main/java/com/selfxdsd/api/Wallets.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Wallets.java
@@ -85,4 +85,10 @@ public interface Wallets extends Iterable<Wallet> {
      */
     Wallet updateCash(final Wallet wallet, final BigDecimal cash);
 
+    /**
+     * Removes a Wallet.
+     * @param wallet Wallet to be removed.
+     * @return True if removed, false otherwise.
+     */
+    boolean remove(final Wallet wallet);
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
@@ -308,6 +308,11 @@ public final class FakeWallet implements Wallet {
     }
 
     @Override
+    public boolean remove() {
+        return this.storage.wallets().remove(this);
+    }
+
+    @Override
     public boolean equals(final Object other) {
         boolean equals;
         if (this == other) {

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/ProjectWallets.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/ProjectWallets.java
@@ -149,8 +149,21 @@ public final class ProjectWallets implements Wallets {
         }
         throw new IllegalStateException(
             "These are the wallets of Project " + project.repoFullName()
-                + " at " + project.provider() + ". You update cash for a Wallet"
-                + " belonging to another Project here."
+            + " at " + project.provider() + ". You update cash for a Wallet"
+            + " belonging to another Project here."
+        );
+    }
+
+    @Override
+    public boolean remove(final Wallet wallet) {
+        if(this.project.equals(wallet.project())) {
+            this.wallets.remove(wallet);
+            return this.storage.wallets().remove(wallet);
+        }
+        throw new IllegalStateException(
+            "These are the wallets of Project " + project.repoFullName()
+            + " at " + project.provider() + ". You cannot remove a Wallet "
+            + "belonging to another Project here."
         );
     }
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/ProjectWallets.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/ProjectWallets.java
@@ -158,7 +158,7 @@ public final class ProjectWallets implements Wallets {
     public boolean remove(final Wallet wallet) {
         if(this.project.equals(wallet.project())) {
             this.wallets.remove(wallet);
-            return this.storage.wallets().remove(wallet);
+            return wallet.remove();
         }
         throw new IllegalStateException(
             "These are the wallets of Project " + project.repoFullName()

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
@@ -50,6 +50,8 @@ import java.util.Objects;
  * @version $Id$
  * @since 0.0.27
  * @checkstyle ExecutableStatementCount (1000 lines)
+ * @todo #1004:60min Method remove() in this class should remove the wallet
+ *  (Customer) from Stripe before removing it from our Storage.
  */
 public final class StripeWallet implements Wallet {
 
@@ -391,6 +393,11 @@ public final class StripeWallet implements Wallet {
                 ex
             );
         }
+    }
+
+    @Override
+    public boolean remove() {
+        return this.storage.wallets().remove(this);
     }
 
     @Override

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryWallets.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryWallets.java
@@ -123,6 +123,11 @@ public final class InMemoryWallets implements Wallets {
     }
 
     @Override
+    public boolean remove(final Wallet wallet) {
+        throw new UnsupportedOperationException("Not yet implemented.");
+    }
+
+    @Override
     public Iterator<Wallet> iterator() {
         throw new UnsupportedOperationException(
             "You cannot iterate over all wallets in Self. "

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/FakeWalletTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/FakeWalletTestCase.java
@@ -473,4 +473,29 @@ public final class FakeWalletTestCase {
 
     }
 
+    /**
+     * FakeWallet can remove itself.
+     */
+    @Test
+    public void removesItself() {
+        final Wallets all = Mockito.mock(Wallets.class);
+        final Storage storage = Mockito.mock(Storage.class);
+        Mockito.when(storage.wallets()).thenReturn(all);
+
+        final Wallet fake = new FakeWallet(
+            storage,
+            Mockito.mock(Project.class),
+            BigDecimal.valueOf(1000),
+            "123FakeID",
+            Boolean.TRUE
+        );
+
+        Mockito.when(all.remove(fake)).thenReturn(true);
+
+        MatcherAssert.assertThat(
+            fake.remove(),
+            Matchers.is(Boolean.TRUE)
+        );
+        Mockito.verify(all, Mockito.times(1)).remove(fake);
+    }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/ProjectWalletsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/ProjectWalletsTestCase.java
@@ -316,17 +316,13 @@ public final class ProjectWalletsTestCase {
     @Test
     public void removeWalletWorks(){
         final Wallet wallet = Mockito.mock(Wallet.class);
-
-        final Wallets all = Mockito.mock(Wallets.class);
-        Mockito.when(all.remove(wallet)).thenReturn(true);
-        final Storage storage = Mockito.mock(Storage.class);
-        Mockito.when(storage.wallets()).thenReturn(all);
+        Mockito.when(wallet.remove()).thenReturn(Boolean.TRUE);
 
         final Project project = Mockito.mock(Project.class);
         final Wallets wallets = new ProjectWallets(
             project,
             List.of(wallet, Mockito.mock(Wallet.class)),
-            storage
+            Mockito.mock(Storage.class)
         );
         Mockito.when(wallet.project()).thenReturn(project);
 
@@ -342,7 +338,7 @@ public final class ProjectWalletsTestCase {
             wallets,
             Matchers.iterableWithSize(1)
         );
-        Mockito.verify(all, Mockito.times(1)).remove(wallet);
+        Mockito.verify(wallet, Mockito.times(1)).remove();
     }
 
     /**

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/ProjectWalletsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/ProjectWalletsTestCase.java
@@ -309,4 +309,57 @@ public final class ProjectWalletsTestCase {
         Mockito.when(wallet.project()).thenReturn(Mockito.mock(Project.class));
         wallets.updateCash(wallet, BigDecimal.TEN);
     }
+
+    /**
+     * ProjectWallets.remove(...) works.
+     */
+    @Test
+    public void removeWalletWorks(){
+        final Wallet wallet = Mockito.mock(Wallet.class);
+
+        final Wallets all = Mockito.mock(Wallets.class);
+        Mockito.when(all.remove(wallet)).thenReturn(true);
+        final Storage storage = Mockito.mock(Storage.class);
+        Mockito.when(storage.wallets()).thenReturn(all);
+
+        final Project project = Mockito.mock(Project.class);
+        final Wallets wallets = new ProjectWallets(
+            project,
+            List.of(wallet, Mockito.mock(Wallet.class)),
+            storage
+        );
+        Mockito.when(wallet.project()).thenReturn(project);
+
+        MatcherAssert.assertThat(
+            wallets,
+            Matchers.iterableWithSize(2)
+        );
+        MatcherAssert.assertThat(
+            wallets.remove(wallet),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            wallets,
+            Matchers.iterableWithSize(1)
+        );
+        Mockito.verify(all, Mockito.times(1)).remove(wallet);
+    }
+
+    /**
+     * ProjectWallets.remove(...) complains if the given Wallet
+     * belongs to another project.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void complainsWhenRemoveWallet(){
+        final Storage storage = Mockito.mock(Storage.class);
+        final Project project = Mockito.mock(Project.class);
+        final Wallet wallet = Mockito.mock(Wallet.class);
+        final Wallets wallets = new ProjectWallets(
+            project,
+            List.of(Mockito.mock(Wallet.class)),
+            storage
+        );
+        Mockito.when(wallet.project()).thenReturn(Mockito.mock(Project.class));
+        wallets.remove(wallet);
+    }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/StripePaymentMethodTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/StripePaymentMethodTestCase.java
@@ -228,6 +228,11 @@ public final class StripePaymentMethodTestCase {
             }
 
             @Override
+            public boolean remove() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
             public int hashCode() {
                 return Objects.hash(type, repoFullName, provider);
             }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/StripeWalletTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/StripeWalletTestCase.java
@@ -331,4 +331,30 @@ public final class StripeWalletTestCase {
 
         stripe.pay(invoice);
     }
+
+    /**
+     * StripeWallet can remove itself.
+     */
+    @Test
+    public void removesItself() {
+        final Wallets all = Mockito.mock(Wallets.class);
+        final Storage storage = Mockito.mock(Storage.class);
+        Mockito.when(storage.wallets()).thenReturn(all);
+
+        final Wallet stripe = new StripeWallet(
+            storage,
+            Mockito.mock(Project.class),
+            BigDecimal.valueOf(1000),
+            "123StripeID",
+            Boolean.TRUE
+        );
+
+        Mockito.when(all.remove(stripe)).thenReturn(true);
+
+        MatcherAssert.assertThat(
+            stripe.remove(),
+            Matchers.is(Boolean.TRUE)
+        );
+        Mockito.verify(all, Mockito.times(1)).remove(stripe);
+    }
 }


### PR DESCRIPTION
Fixes #1004 

Implemented and tested Wallets.remove(Wallet);
Implemented and tested Wallet.remove();
Added puzzle for StripeWallet.remove() (needs to also remove the Customer from Stripe);