### PR TITLE
#1030 Wallet.activate() implemented and tested

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Wallet.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Wallet.java
@@ -124,6 +124,12 @@ public interface Wallet {
     BillingInfo billingInfo();
 
     /**
+     * Activate this wallet.
+     * @return Activated wallet.
+     */
+    Wallet activate();
+
+    /**
      * Remove this Wallet.
      * @return True if removed, false otherwise.
      */

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
@@ -308,6 +308,17 @@ public final class FakeWallet implements Wallet {
     }
 
     @Override
+    public Wallet activate() {
+        final Wallet activated;
+        if(this.active) {
+            activated = this;
+        } else {
+            activated = this.storage.wallets().activate(this);
+        }
+        return activated;
+    }
+
+    @Override
     public boolean remove() {
         return this.storage.wallets().remove(this);
     }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
@@ -394,6 +394,24 @@ public final class StripeWallet implements Wallet {
     }
 
     @Override
+    public Wallet activate() {
+        final Wallet activated;
+        if(this.active) {
+            activated = this;
+        } else {
+            final Wallets all = this.storage.wallets();
+            activated = all.activate(this);
+            for (final Wallet wallet : all.ofProject(this.project)) {
+                if (Type.FAKE.equalsIgnoreCase(wallet.type())) {
+                    wallet.remove();
+                    break;
+                }
+            }
+        }
+        return activated;
+    }
+
+    @Override
     public boolean remove() {
         final String apiToken = System.getenv(Env.STRIPE_API_TOKEN);
         if(apiToken == null || apiToken.trim().isEmpty()) {

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/FakeWalletTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/FakeWalletTestCase.java
@@ -498,4 +498,52 @@ public final class FakeWalletTestCase {
         );
         Mockito.verify(all, Mockito.times(1)).remove(fake);
     }
+
+    /**
+     * FakeWallet can activate itself if not active.
+     */
+    @Test
+    public void activatesItselfIfNotActive() {
+        final Wallets all = Mockito.mock(Wallets.class);
+        final Storage storage = Mockito.mock(Storage.class);
+        Mockito.when(storage.wallets()).thenReturn(all);
+
+        final Wallet fake = new FakeWallet(
+            storage,
+            Mockito.mock(Project.class),
+            BigDecimal.valueOf(1000),
+            "123FakeID",
+            Boolean.FALSE
+        );
+
+        final Wallet activated = Mockito.mock(Wallet.class);
+        Mockito.when(all.activate(fake)).thenReturn(activated);
+
+        MatcherAssert.assertThat(
+            fake.activate(),
+            Matchers.is(activated)
+        );
+        Mockito.verify(
+            all,
+            Mockito.times(1)
+        ).activate(fake);
+    }
+
+    /**
+     * It will return itself if already active.
+     */
+    @Test
+    public void activateReturnsSelfIfActive() {
+        final Wallet fake = new FakeWallet(
+            Mockito.mock(Storage.class),
+            Mockito.mock(Project.class),
+            BigDecimal.valueOf(1000),
+            "123FakeID",
+            Boolean.TRUE
+        );
+        MatcherAssert.assertThat(
+            fake.activate(),
+            Matchers.is(fake)
+        );
+    }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/StripePaymentMethodTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/StripePaymentMethodTestCase.java
@@ -228,6 +228,11 @@ public final class StripePaymentMethodTestCase {
             }
 
             @Override
+            public Wallet activate() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
             public boolean remove() {
                 throw new UnsupportedOperationException();
             }


### PR DESCRIPTION
Fixes #1030 

Implemented FakeWallet.activate() which activates self or returns self if already active;
Implemented StripeWallet.activate() which activates self (and removes the Project's FakeWallet if present) or returns self if already active;
Added unit tests;