### PR TITLE
#1026 Invoices.registerAsPaid(...) returns Payment

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Invoices.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Invoices.java
@@ -43,14 +43,16 @@ public interface Invoices extends Iterable<Invoice> {
     Invoices ofContract(final Contract.Id id);
 
     /**
-     * Register an Invoice as paid.
+     * Register an Invoice as paid. You should call this method only when
+     * you're sure that the Invoice has been paid successfully.
+     *
      * @param invoice Paid invoice.
      * @param contributorVat Vat which Self takes from the Contributor.
      * @param eurToRon Euro to RON (Romanian Leu) conversion rate.
      *  For example, if the value is 487, it means 1 EUR = 4,87 RON.
-     * @return True or false, depending on whether the operation succeeded.
+     * @return Payment.
      */
-    boolean registerAsPaid(
+    Payment registerAsPaid(
         final Invoice invoice,
         final BigDecimal contributorVat,
         final BigDecimal eurToRon

--- a/self-api/src/main/java/com/selfxdsd/api/Wallet.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Wallet.java
@@ -64,7 +64,7 @@ public interface Wallet {
      * @param invoice The Invoice to be paid.
      * @return Wallet having cash deducted with Invoice amount.
      *
-     * @todo #1026:60min Modify method pay(...) to return the Payment created
+     * @todo #1026:180min Modify method pay(...) to return the Payment created
      *  by Invoices.registerAsPai(...).
      */
     Wallet pay(final Invoice invoice);

--- a/self-api/src/main/java/com/selfxdsd/api/Wallet.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Wallet.java
@@ -64,9 +64,8 @@ public interface Wallet {
      * @param invoice The Invoice to be paid.
      * @return Wallet having cash deducted with Invoice amount.
      *
-     * @todo #979:60min Modify this method to create & return a Payment object.
-     *  A payment could be successful or failed in both cases all related info
-     *  should be in the returned Payment object.
+     * @todo #1026:60min Modify method pay(...) to return the Payment created
+     *  by Invoices.registerAsPai(...).
      */
     Wallet pay(final Invoice invoice);
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/ContractInvoices.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/ContractInvoices.java
@@ -25,6 +25,7 @@ package com.selfxdsd.core.contracts.invoices;
 import com.selfxdsd.api.Contract;
 import com.selfxdsd.api.Invoice;
 import com.selfxdsd.api.Invoices;
+import com.selfxdsd.api.Payment;
 import com.selfxdsd.api.storage.Storage;
 
 import java.math.BigDecimal;
@@ -90,7 +91,7 @@ public final class ContractInvoices implements Invoices {
     }
 
     @Override
-    public boolean registerAsPaid(
+    public Payment registerAsPaid(
         final Invoice invoice,
         final BigDecimal contributorVat,
         final BigDecimal eurToRon

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
@@ -132,7 +132,7 @@ public final class FakeWallet implements Wallet {
             + "..."
         );
         final String uuid = UUID.randomUUID().toString().replace("-", "");
-        final boolean paid = this.storage
+        this.storage
             .invoices()
             .registerAsPaid(
                 new StoredInvoice(
@@ -151,11 +151,6 @@ public final class FakeWallet implements Wallet {
                 BigDecimal.valueOf(0),
                 BigDecimal.valueOf(0)
             );
-        if (!paid) {
-            throw new WalletPaymentException(
-                "Could not pay invoice #" + invoice.invoiceId()
-            );
-        }
         return this.updateCash(newCash);
     }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/ContractInvoicesTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/ContractInvoicesTestCase.java
@@ -22,10 +22,7 @@
  */
 package com.selfxdsd.core.contracts.invoices;
 
-import com.selfxdsd.api.Contract;
-import com.selfxdsd.api.Invoice;
-import com.selfxdsd.api.Invoices;
-import com.selfxdsd.api.Provider;
+import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -221,9 +218,10 @@ public final class ContractInvoicesTestCase {
         Mockito.when(contract.contractId()).thenReturn(contractId);
 
         final Invoices all = Mockito.mock(Invoices.class);
+        final Payment payment = Mockito.mock(Payment.class);
         Mockito.when(
             all.registerAsPaid(invoice, contributorVat, eurToRon)
-        ).thenReturn(Boolean.TRUE);
+        ).thenReturn(payment);
         final Storage storage = Mockito.mock(Storage.class);
         Mockito.when(storage.invoices()).thenReturn(all);
 
@@ -235,7 +233,7 @@ public final class ContractInvoicesTestCase {
 
         MatcherAssert.assertThat(
             invoices.registerAsPaid(invoice, contributorVat, eurToRon),
-            Matchers.is(Boolean.TRUE)
+            Matchers.is(payment)
         );
     }
 
@@ -267,9 +265,10 @@ public final class ContractInvoicesTestCase {
         );
 
         final Invoices all = Mockito.mock(Invoices.class);
+        final Payment payment = Mockito.mock(Payment.class);
         Mockito.when(
             all.registerAsPaid(invoice, contributorVat, eurToRon)
-        ).thenReturn(Boolean.TRUE);
+        ).thenReturn(payment);
         final Storage storage = Mockito.mock(Storage.class);
         Mockito.when(storage.invoices()).thenReturn(all);
 
@@ -281,7 +280,7 @@ public final class ContractInvoicesTestCase {
 
         MatcherAssert.assertThat(
             invoices.registerAsPaid(invoice, contributorVat, eurToRon),
-            Matchers.is(Boolean.TRUE)
+            Matchers.is(payment)
         );
     }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryInvoices.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/InMemoryInvoices.java
@@ -55,13 +55,13 @@ public final class InMemoryInvoices implements Invoices {
     }
 
     @Override
-    public boolean registerAsPaid(
+    public Payment registerAsPaid(
         final Invoice invoice,
         final BigDecimal contributorVat,
         final BigDecimal eurToRon
     ) {
         this.invoices.put(invoice.invoiceId(), invoice);
-        return true;
+        return null;
     }
 
     @Override

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/FakeWalletTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/FakeWalletTestCase.java
@@ -395,13 +395,14 @@ public final class FakeWalletTestCase {
 
         final Invoices invoices = Mockito.mock(Invoices.class);
         Mockito.when(storage.invoices()).thenReturn(invoices);
+        final Payment payment = Mockito.mock(Payment.class);
         Mockito.when(
             invoices.registerAsPaid(
                 Mockito.any(Invoice.class),
                 Mockito.any(BigDecimal.class),
                 Mockito.any(BigDecimal.class)
             )
-        ).thenReturn(true);
+        ).thenReturn(payment);
 
         final Wallet updated = new FakeWallet(
             storage,
@@ -431,46 +432,6 @@ public final class FakeWalletTestCase {
             Matchers.notNullValue());
         MatcherAssert.assertThat(paidInvoice.transactionId(),
             Matchers.notNullValue());
-    }
-
-
-    /**
-     * FakeWallet.pay(...) throws WalletException if something went wrong
-     * when paying the invoice.
-     */
-    @Test(expected = WalletPaymentException.class)
-    public void complainsIfSomethingWentWrongWhenPayInvoice() {
-        final Project project = Mockito.mock(Project.class);
-
-        final Invoice invoice = Mockito.mock(Invoice.class);
-        Mockito.when(invoice.isPaid()).thenReturn(false);
-        Mockito.when(invoice.totalAmount()).thenReturn(BigDecimal.TEN);
-        Mockito.when(invoice.invoiceId()).thenReturn(1);
-
-        final Contract contract = Mockito.mock(Contract.class);
-        Mockito.when(contract.project()).thenReturn(project);
-        Mockito.when(invoice.contract())
-            .thenReturn(contract);
-
-        final Storage storage = Mockito.mock(Storage.class);
-        final Invoices invoices = Mockito.mock(Invoices.class);
-        Mockito.when(storage.invoices()).thenReturn(invoices);
-        Mockito.when(
-            invoices.registerAsPaid(
-                Mockito.any(Invoice.class),
-                Mockito.any(BigDecimal.class),
-                Mockito.any(BigDecimal.class)
-            )
-        ).thenReturn(false);
-
-        new FakeWallet(
-            storage,
-            project,
-            BigDecimal.TEN,
-            "id",
-            true
-        ).pay(invoice);
-
     }
 
     /**


### PR DESCRIPTION
Changes Invoice.registerAsPaid(...) to return the (successful) Payment.

We will register the succesful Payment through this method because it has to be done in the same transaction together with the update of the Invoice and creation of the PlatformInvoice (in the storage).

Updated tests.
Left puzzle to continue with Wallet.pay(...);