### PR TITLE
BitbucketCommit from BitbucketCommits URI fix.

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/BitbucketCommit.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/BitbucketCommit.java
@@ -102,23 +102,21 @@ final class BitbucketCommit implements Commit {
      */
     @Override
     public String author() {
-        return this.json
-            .getJsonArray("values")
-            .getJsonObject(0)
-            .getJsonObject("author")
-            .getString("account_id");
+        return this.json.getJsonObject("author").getString("account_id");
     }
 
     @Override
     public String shaRef() {
-        return this.json
-            .getJsonArray("values")
-            .getJsonObject(0)
-            .getString("hash");
+        return this.json.getString("hash");
     }
 
     @Override
     public JsonObject json() {
         return this.json;
+    }
+
+    @Override
+    public String toString() {
+        return this.commitUri.toString();
     }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/BitbucketCommitsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/BitbucketCommitsTestCase.java
@@ -67,18 +67,14 @@ public final class BitbucketCommitsTestCase {
             req -> new MockJsonResources.MockResource(
                 HttpURLConnection.HTTP_OK,
                 Json.createObjectBuilder()
-                    .add("values", Json.createArrayBuilder()
-                        .add(Json.createObjectBuilder()
-                            .add("hash",
-                                "84899952ccf723fe5e4306aac2c857f05ef4686a")
-                            .add("author", Json.createObjectBuilder()
-                                .add("account_id",
-                                    "601e661dcd564b00686f4e4b")
-                                .build())
-                            .build())
-                        .build()
-                    )
+                    .add("hash",
+                        "84899952ccf723fe5e4306aac2c857f05ef4686a")
+                    .add("author", Json.createObjectBuilder()
+                        .add("account_id",
+                            "601e661dcd564b00686f4e4b")
+                        .build())
                     .build()
+
             )
         );
         final Commits commits = new BitbucketCommits(
@@ -98,7 +94,7 @@ public final class BitbucketCommitsTestCase {
             req.getUri().toString(),
             Matchers.equalTo(
                 "https://bitbucket.org/api/2.0/repositories"
-                    + "/crisketm/my-super-repo/commits"
+                    + "/crisketm/my-super-repo/commit"
                     + "/13f74048cd8b4c2fdafdf0d45771c1cf73b998de"
             )
         );
@@ -109,6 +105,12 @@ public final class BitbucketCommitsTestCase {
         MatcherAssert.assertThat(
             found.shaRef(),
             Matchers.equalTo("84899952ccf723fe5e4306aac2c857f05ef4686a")
+        );
+        MatcherAssert.assertThat(
+            found.toString(),
+            Matchers.equalTo("https://bitbucket.org/api/2.0/repositories"
+                + "/crisketm/my-super-repo/commit"
+                + "/13f74048cd8b4c2fdafdf0d45771c1cf73b998de")
         );
     }
 
@@ -202,6 +204,12 @@ public final class BitbucketCommitsTestCase {
         MatcherAssert.assertThat(
             latest.shaRef(),
             Matchers.equalTo("13f74048cd8b4c2fdafdf0d45771c1cf73b998de")
+        );
+        MatcherAssert.assertThat(
+            latest.toString(),
+            Matchers.equalTo("https://bitbucket.org/api/2.0/repositories"
+                + "/crisketm/my-super-repo/commit"
+                + "/13f74048cd8b4c2fdafdf0d45771c1cf73b998de")
         );
     }
 


### PR DESCRIPTION
The URIs for `BitbucketCommit` from `BitbucketCommits#getCommit()` and `BitbucketCommits#latest()` were wrong.

They were created by adding the ref to the base of commits URI.
`/<owner>/<name>/commits` -> `/<owner>/<name>/commits/hash`
But the correct form is `/<owner>/<name>/commit/hash` (commit not commits)

Interesting that when calling `getCommit()`, Bitbucket won't complain about it, and the result was just a json commits with a single commit.
Based on this, the extracted `BitbucketCommit` json from that result was wrong too. (it shouldn't contain the "values" property).