### PR TITLE
#1034 Wallet.pay(...) returns the registered Payment

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Wallet.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Wallet.java
@@ -63,11 +63,14 @@ public interface Wallet {
      * Pay an invoice.
      * @param invoice The Invoice to be paid.
      * @return Wallet having cash deducted with Invoice amount.
-     *
-     * @todo #1026:180min Modify method pay(...) to return the Payment created
-     *  by Invoices.registerAsPai(...).
+     * @todo #1034:90min Write a Wallet decorator which will perform all the
+     *  required pre-checks before making a payment (invoice is not paid, the
+     *  cash limit is not exceeded etc).
+     * @todo #1034:90min Write a Wallet decorator which will catch any
+     *  WalletPaymentException or IllegalStateException thrown from this method
+     *  and register a failed Payment for it.
      */
-    Wallet pay(final Invoice invoice);
+    Payment pay(final Invoice invoice);
 
     /**
      * Type of this wallet.

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
@@ -108,7 +108,7 @@ public final class FakeWallet implements Wallet {
     }
 
     @Override
-    public Wallet pay(final Invoice invoice) {
+    public Payment pay(final Invoice invoice) {
         if (!this.project.equals(invoice.contract().project())) {
             throw new InvoiceException.NotPartOfProjectContract(invoice,
                 this.project);
@@ -132,7 +132,7 @@ public final class FakeWallet implements Wallet {
             + "..."
         );
         final String uuid = UUID.randomUUID().toString().replace("-", "");
-        this.storage
+        final Payment payment = this.storage
             .invoices()
             .registerAsPaid(
                 new StoredInvoice(
@@ -151,7 +151,8 @@ public final class FakeWallet implements Wallet {
                 BigDecimal.valueOf(0),
                 BigDecimal.valueOf(0)
             );
-        return this.updateCash(newCash);
+        this.updateCash(newCash);
+        return payment;
     }
 
     @Override

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/FakeWalletTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/FakeWalletTestCase.java
@@ -404,7 +404,7 @@ public final class FakeWalletTestCase {
             )
         ).thenReturn(payment);
 
-        final Wallet updated = new FakeWallet(
+        final Payment successful = new FakeWallet(
             storage,
             project,
             BigDecimal.TEN,
@@ -412,8 +412,10 @@ public final class FakeWalletTestCase {
             true
         ).pay(invoice);
 
-        MatcherAssert.assertThat(updated.cash(),
-            Matchers.equalTo(BigDecimal.ZERO));
+        MatcherAssert.assertThat(
+            payment,
+            Matchers.is(successful)
+        );
 
         final ArgumentCaptor<Invoice> paidInvoiceCapture = ArgumentCaptor
             .forClass(Invoice.class);

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/StripePaymentMethodTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/StripePaymentMethodTestCase.java
@@ -181,7 +181,7 @@ public final class StripePaymentMethodTestCase {
             }
 
             @Override
-            public Wallet pay(final Invoice invoice) {
+            public Payment pay(final Invoice invoice) {
                 throw new UnsupportedOperationException();
             }
 


### PR DESCRIPTION
Wallet.pay(...) now returns the registered (successful) Payment. 

Exceptions from the payment process are going to be caught in a decorator and registered as failed Payment. 
We will also write a decorator to pull out all the payment pre-checks. 