### PR TITLE
#1056 StoredPayment Takes invoiceId

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/StoredPayment.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/StoredPayment.java
@@ -40,9 +40,9 @@ import java.util.Objects;
 public final class StoredPayment implements Payment {
 
     /**
-     * Invoice to which this payment made.
+     * Id of the Invoice to which this Payment belongs.
      */
-    private final Invoice invoice;
+    private int invoiceId;
 
     /**
      * Successful Payment transaction id.
@@ -76,7 +76,7 @@ public final class StoredPayment implements Payment {
 
     /**
      * Ctor.
-     * @param invoice The Invoice to which this payment made.
+     * @param invoiceId Id of the Invoice to which this Payment belongs.
      * @param transactionId Successful payment transaction id.
      * @param paymentTime Payment time.
      * @param value Payment amount.
@@ -84,15 +84,16 @@ public final class StoredPayment implements Payment {
      * @param failReason Payment failure reason.
      * @param storage Self Storage.
      */
-    public StoredPayment(final Invoice invoice,
-                         final String transactionId,
-                         final LocalDateTime paymentTime,
-                         final BigDecimal value,
-                         final String status,
-                         final String failReason,
-                         final Storage storage
+    public StoredPayment(
+        final int invoiceId,
+        final String transactionId,
+        final LocalDateTime paymentTime,
+        final BigDecimal value,
+        final String status,
+        final String failReason,
+        final Storage storage
     ) {
-        this.invoice = invoice;
+        this.invoiceId = invoiceId;
         this.transactionId = transactionId;
         this.paymentTime = paymentTime;
         this.value = value;
@@ -103,7 +104,7 @@ public final class StoredPayment implements Payment {
 
     @Override
     public Invoice invoice() {
-        return this.invoice;
+        return this.storage.invoices().getById(this.invoiceId);
     }
 
     @Override
@@ -148,7 +149,7 @@ public final class StoredPayment implements Payment {
     @Override
     public int hashCode() {
         return Objects.hash(
-            this.invoice().invoiceId(),
+            this.invoiceId,
             this.paymentTime()
         );
     }
@@ -156,7 +157,7 @@ public final class StoredPayment implements Payment {
     @Override
     public boolean equals(final Object obj) {
         return this == obj || (obj instanceof StoredPayment
-            && this.invoice().equals(((Payment) obj).invoice())
+            && this.invoiceId == ((StoredPayment) obj).invoiceId
             && this.paymentTime() == ((Payment) obj).paymentTime());
     }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/StoredPayment.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contracts/invoices/StoredPayment.java
@@ -150,7 +150,8 @@ public final class StoredPayment implements Payment {
     public int hashCode() {
         return Objects.hash(
             this.invoiceId,
-            this.paymentTime()
+            this.paymentTime,
+            this.transactionId
         );
     }
 
@@ -158,6 +159,7 @@ public final class StoredPayment implements Payment {
     public boolean equals(final Object obj) {
         return this == obj || (obj instanceof StoredPayment
             && this.invoiceId == ((StoredPayment) obj).invoiceId
-            && this.paymentTime() == ((Payment) obj).paymentTime());
+            && this.paymentTime.isEqual(((StoredPayment) obj).paymentTime)
+            && this.transactionId.equals(((StoredPayment) obj).transactionId));
     }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
@@ -123,7 +123,7 @@ public final class FakeWallet implements Wallet {
                     invoice.contract(),
                     invoice.createdAt(),
                     new StoredPayment(
-                        invoice,
+                        invoice.invoiceId(),
                         "fake_payment_" + uuid,
                         LocalDateTime.now(),
                         totalAmount,

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
@@ -243,7 +243,7 @@ public final class StripeWallet implements Wallet {
                             invoice.contract(),
                             invoice.createdAt(),
                             new StoredPayment(
-                                invoice,
+                                invoice.invoiceId(),
                                 paymentIntent.getId(),
                                 paymentDate,
                                 totalAmount,

--- a/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/StoredPaymentTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/contracts/invoices/StoredPaymentTestCase.java
@@ -22,10 +22,7 @@
  */
 package com.selfxdsd.core.contracts.invoices;
 
-import com.selfxdsd.api.Invoice;
-import com.selfxdsd.api.Payment;
-import com.selfxdsd.api.PlatformInvoice;
-import com.selfxdsd.api.PlatformInvoices;
+import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -51,15 +48,20 @@ public final class StoredPaymentTestCase {
     @Test
     public void hasInvoice() {
         final Invoice invoice = Mockito.mock(Invoice.class);
+        final Invoices all = Mockito.mock(Invoices.class);
+        Mockito.when(all.getById(1)).thenReturn(invoice);
+        final Storage storage = Mockito.mock(Storage.class);
+        Mockito.when(storage.invoices()).thenReturn(all);
+
         MatcherAssert.assertThat(
             new StoredPayment(
-                invoice,
+                1,
                 "123",
                 LocalDateTime.now(),
                 BigDecimal.TEN,
                 Payment.Status.SUCCESSFUL,
                 "",
-                Mockito.mock(Storage.class)
+                storage
             ).invoice(),
             Matchers.is(invoice)
         );
@@ -79,7 +81,7 @@ public final class StoredPaymentTestCase {
             .thenReturn(found);
         MatcherAssert.assertThat(
             new StoredPayment(
-                Mockito.mock(Invoice.class),
+                1,
                 "123",
                 paymentTime,
                 BigDecimal.TEN,
@@ -98,7 +100,7 @@ public final class StoredPaymentTestCase {
     public void nullPlatformInvoiceForFailedPayment() {
         MatcherAssert.assertThat(
             new StoredPayment(
-                Mockito.mock(Invoice.class),
+                1,
                 "123",
                 LocalDateTime.now(),
                 BigDecimal.TEN,
@@ -117,7 +119,7 @@ public final class StoredPaymentTestCase {
     public void hasTransactionId() {
         MatcherAssert.assertThat(
             new StoredPayment(
-                Mockito.mock(Invoice.class),
+                1,
                 "123",
                 LocalDateTime.now(),
                 BigDecimal.TEN,
@@ -137,7 +139,7 @@ public final class StoredPaymentTestCase {
         final LocalDateTime paymentTime = LocalDateTime.now();
         MatcherAssert.assertThat(
             new StoredPayment(
-                Mockito.mock(Invoice.class),
+                1,
                 "123",
                 paymentTime,
                 BigDecimal.TEN,
@@ -156,7 +158,7 @@ public final class StoredPaymentTestCase {
     public void hasValue() {
         MatcherAssert.assertThat(
             new StoredPayment(
-                Mockito.mock(Invoice.class),
+                1,
                 "123",
                 LocalDateTime.now(),
                 BigDecimal.TEN,
@@ -175,7 +177,7 @@ public final class StoredPaymentTestCase {
     public void hasStatus() {
         MatcherAssert.assertThat(
             new StoredPayment(
-                Mockito.mock(Invoice.class),
+                1,
                 "123",
                 LocalDateTime.now(),
                 BigDecimal.TEN,
@@ -194,7 +196,7 @@ public final class StoredPaymentTestCase {
     public void failReason() {
         MatcherAssert.assertThat(
             new StoredPayment(
-                Mockito.mock(Invoice.class),
+                1,
                 "",
                 LocalDateTime.now(),
                 BigDecimal.TEN,
@@ -211,10 +213,9 @@ public final class StoredPaymentTestCase {
      */
     @Test
     public void areEquals() {
-        Invoice invoice = Mockito.mock(Invoice.class);
         LocalDateTime paymentTime = LocalDateTime.now();
         final Payment first = new StoredPayment(
-            invoice,
+            1,
             "123",
             paymentTime,
             BigDecimal.TEN,
@@ -224,7 +225,7 @@ public final class StoredPaymentTestCase {
         );
 
         final Payment second = new StoredPayment(
-            invoice,
+            1,
             "123",
             paymentTime,
             BigDecimal.TEN,
@@ -250,7 +251,7 @@ public final class StoredPaymentTestCase {
     @Test
     public void notEquals() {
         final Payment first = new StoredPayment(
-            Mockito.mock(Invoice.class),
+            1,
             "123",
             LocalDateTime.MAX,
             BigDecimal.TEN,
@@ -260,7 +261,7 @@ public final class StoredPaymentTestCase {
         );
 
         final Payment second = new StoredPayment(
-            Mockito.mock(Invoice.class),
+            2,
             "123",
             LocalDateTime.MIN,
             BigDecimal.TEN,


### PR DESCRIPTION
Fixes #1056 

StoredPayment takes only invoiceId; 
Updated method StoredPayment.invoice() and the unit tests;
Fixed equals and hashcode for StoredPayment;