### PR TITLE
Decorator Wallets use equals/hashCode of original.

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/PreCheckPayments.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/PreCheckPayments.java
@@ -143,4 +143,14 @@ public final class PreCheckPayments implements Wallet  {
     public boolean remove() {
         return this.original.remove();
     }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return this.original.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.original.hashCode();
+    }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/RegisterUnsuccessfulPayments.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/RegisterUnsuccessfulPayments.java
@@ -126,4 +126,14 @@ public final class RegisterUnsuccessfulPayments implements Wallet  {
     public boolean remove() {
         return this.original.remove();
     }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return this.original.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.original.hashCode();
+    }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/PreCheckPaymentsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/PreCheckPaymentsTestCase.java
@@ -320,4 +320,26 @@ public final class PreCheckPaymentsTestCase {
         );
         Mockito.verify(original, Mockito.times(1)).remove();
     }
+
+    /**
+     * Delegates the equals() method to the original.
+     */
+    @Test
+    public void delegatesEquals(){
+        final Wallet original = Mockito.mock(Wallet.class);
+        final Wallet preCheck = new PreCheckPayments(original);
+        MatcherAssert.assertThat(preCheck.equals(original),
+            Matchers.is(Boolean.TRUE));
+    }
+
+    /**
+     * Delegates the equals() method to the original.
+     */
+    @Test
+    public void delegatesHashCode(){
+        final Wallet original = Mockito.mock(Wallet.class);
+        final Wallet preCheck = new PreCheckPayments(original);
+        MatcherAssert.assertThat(preCheck.hashCode(),
+            Matchers.is(original.hashCode()));
+    }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/RegisterUnsuccessfulPaymentsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/RegisterUnsuccessfulPaymentsTestCase.java
@@ -311,4 +311,26 @@ public final class RegisterUnsuccessfulPaymentsTestCase {
         );
         Mockito.verify(original, Mockito.times(1)).remove();
     }
+
+    /**
+     * Delegates the equals() method to the original.
+     */
+    @Test
+    public void delegatesEquals(){
+        final Wallet original = Mockito.mock(Wallet.class);
+        final Wallet preCheck = new RegisterUnsuccessfulPayments(original);
+        MatcherAssert.assertThat(preCheck.equals(original),
+            Matchers.is(Boolean.TRUE));
+    }
+
+    /**
+     * Delegates the equals() method to the original.
+     */
+    @Test
+    public void delegatesHashCode(){
+        final Wallet original = Mockito.mock(Wallet.class);
+        final Wallet preCheck = new RegisterUnsuccessfulPayments(original);
+        MatcherAssert.assertThat(preCheck.hashCode(),
+            Matchers.is(original.hashCode()));
+    }
 }


### PR DESCRIPTION
Otherwise WalletPaymentMethods methods will equality check the  Wallet decorator
instead of it's delegate.