### PR TITLE
Wallet impls equals are now based on project and type.

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/FakeWallet.java
@@ -315,12 +315,12 @@ public final class FakeWallet implements Wallet {
         if (this == other) {
             equals = true;
         } else {
-            if (other == null || getClass() != other.getClass()) {
+            if (!(other instanceof Wallet)) {
                 equals = false;
             } else {
-                final FakeWallet missing = (FakeWallet) other;
-                equals = this.project.equals(missing.project)
-                    && this.type().equals(missing.type());
+                final Wallet otherWallet = (Wallet) other;
+                equals = this.type().equals(otherWallet.type())
+                    && this.project.equals(otherWallet.project());
             }
         }
         return equals;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
@@ -465,11 +465,12 @@ public final class StripeWallet implements Wallet {
         if (this == other) {
             equals = true;
         } else {
-            if (other == null || getClass() != other.getClass()) {
+            if (!(other instanceof Wallet)) {
                 equals = false;
             } else {
-                final StripeWallet stripeWallet = (StripeWallet) other;
-                equals = this.project.equals(stripeWallet.project);
+                final Wallet otherWallet = (Wallet) other;
+                equals = this.type().equals(otherWallet.type())
+                    && this.project.equals(otherWallet.project());
             }
         }
         return equals;
@@ -477,7 +478,7 @@ public final class StripeWallet implements Wallet {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.project);
+        return Objects.hash(this.project, this.type());
     }
 
     /**
@@ -524,4 +525,6 @@ public final class StripeWallet implements Wallet {
         }
         return calculated;
     }
+
+
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/PreCheckPaymentsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/PreCheckPaymentsTestCase.java
@@ -25,6 +25,7 @@ package com.selfxdsd.core.projects;
 import com.selfxdsd.api.*;
 import com.selfxdsd.api.exceptions.InvoiceException;
 import com.selfxdsd.api.exceptions.WalletPaymentException;
+import com.selfxdsd.api.storage.Storage;
 import com.stripe.model.SetupIntent;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -326,10 +327,40 @@ public final class PreCheckPaymentsTestCase {
      */
     @Test
     public void delegatesEquals(){
-        final Wallet original = Mockito.mock(Wallet.class);
-        final Wallet preCheck = new PreCheckPayments(original);
-        MatcherAssert.assertThat(preCheck.equals(original),
+        final Wallet stripe = new StripeWallet(
+            Mockito.mock(Storage.class),
+            Mockito.mock(Project.class),
+            BigDecimal.TEN,
+            "1",
+            false
+        );
+        final Wallet fake = new FakeWallet(
+            Mockito.mock(Storage.class),
+            Mockito.mock(Project.class),
+            BigDecimal.TEN,
+            "1",
+            false
+        );
+        final Wallet preCheckStripe = new PreCheckPayments(stripe);
+        final Wallet preCheckFake = new PreCheckPayments(fake);
+
+        MatcherAssert.assertThat(preCheckStripe.equals(stripe),
             Matchers.is(Boolean.TRUE));
+        MatcherAssert.assertThat(stripe.equals(preCheckStripe),
+            Matchers.is(Boolean.TRUE));
+        MatcherAssert.assertThat(preCheckFake.equals(fake),
+            Matchers.is(Boolean.TRUE));
+        MatcherAssert.assertThat(fake.equals(preCheckFake),
+            Matchers.is(Boolean.TRUE));
+
+        MatcherAssert.assertThat(preCheckFake.equals(stripe),
+            Matchers.is(Boolean.FALSE));
+        MatcherAssert.assertThat(stripe.equals(preCheckFake),
+            Matchers.is(Boolean.FALSE));
+        MatcherAssert.assertThat(preCheckStripe.equals(fake),
+            Matchers.is(Boolean.FALSE));
+        MatcherAssert.assertThat(fake.equals(preCheckStripe),
+            Matchers.is(Boolean.FALSE));
     }
 
     /**

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/RegisterUnsuccessfulPaymentsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/RegisterUnsuccessfulPaymentsTestCase.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core.projects;
 
 import com.selfxdsd.api.*;
 import com.selfxdsd.api.exceptions.WalletPaymentException;
+import com.selfxdsd.api.storage.Storage;
 import com.stripe.model.SetupIntent;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -317,10 +318,40 @@ public final class RegisterUnsuccessfulPaymentsTestCase {
      */
     @Test
     public void delegatesEquals(){
-        final Wallet original = Mockito.mock(Wallet.class);
-        final Wallet preCheck = new RegisterUnsuccessfulPayments(original);
-        MatcherAssert.assertThat(preCheck.equals(original),
+        final Wallet stripe = new StripeWallet(
+            Mockito.mock(Storage.class),
+            Mockito.mock(Project.class),
+            BigDecimal.TEN,
+            "1",
+            false
+        );
+        final Wallet fake = new FakeWallet(
+            Mockito.mock(Storage.class),
+            Mockito.mock(Project.class),
+            BigDecimal.TEN,
+            "1",
+            false
+        );
+        final Wallet preCheckStripe = new RegisterUnsuccessfulPayments(stripe);
+        final Wallet preCheckFake = new RegisterUnsuccessfulPayments(fake);
+
+        MatcherAssert.assertThat(preCheckStripe.equals(stripe),
             Matchers.is(Boolean.TRUE));
+        MatcherAssert.assertThat(stripe.equals(preCheckStripe),
+            Matchers.is(Boolean.TRUE));
+        MatcherAssert.assertThat(preCheckFake.equals(fake),
+            Matchers.is(Boolean.TRUE));
+        MatcherAssert.assertThat(fake.equals(preCheckFake),
+            Matchers.is(Boolean.TRUE));
+
+        MatcherAssert.assertThat(preCheckFake.equals(stripe),
+            Matchers.is(Boolean.FALSE));
+        MatcherAssert.assertThat(stripe.equals(preCheckFake),
+            Matchers.is(Boolean.FALSE));
+        MatcherAssert.assertThat(preCheckStripe.equals(fake),
+            Matchers.is(Boolean.FALSE));
+        MatcherAssert.assertThat(fake.equals(preCheckStripe),
+            Matchers.is(Boolean.FALSE));
     }
 
     /**


### PR DESCRIPTION
Previous implementations were based on Wallet class comparing and attached project.
But when used with Wallet decorators, the "original" equal implementation
would not ensure commutativity.
Comparing based on Wallet#type instead of Wallet::class fixes the commutativity problem.

```java
Wallet original = StripeWallet(...)
Wallet decorator = PreChekPayments(original)
decorator.equals(original) //TRUE
original.equals(decorator) //FALSE
```