### PR TITLE
#1071 `Commands` implemented + Language linked responses.

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Event.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Event.java
@@ -132,5 +132,10 @@ public interface Event {
          */
         public static final String STATUS = "status";
 
+        /**
+         * Available commands event.
+         */
+        public static final String COMMANDS = "commands";
+
     }
 }

--- a/self-api/src/main/java/com/selfxdsd/api/Language.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Language.java
@@ -25,9 +25,7 @@ package com.selfxdsd.api;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLConnection;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -38,21 +36,18 @@ import java.util.stream.Collectors;
  * @version $Id$
  * @since 0.0.8
  * @checkstyle ReturnCount (100 lines)
- * @todo #1071:60min Continue writing unit tests
- *  for {@link Language#tryReplyFromLink(String)} in order to ensure complete
- *  test coverage.
  */
 public abstract class Language {
 
     /**
      * Commands that the agent can understand, in a given language.
      */
-    private final Properties commands;
+    private final Properties commands = new Properties();
 
     /**
      * Responses that the agent can give, in a given language.
      */
-    private final Properties responses;
+    private final Properties responses = new Properties();
 
     /**
      * Constructor. These two files should be in self-pm, so we don't have
@@ -65,7 +60,6 @@ public abstract class Language {
         final String commandsFileName,
         final String responsesFileName
     ) {
-        this(new Properties(), new Properties());
         try {
             this.commands.load(
                 this.getClass().getClassLoader()
@@ -81,20 +75,6 @@ public abstract class Language {
                 ex
             );
         }
-    }
-
-    /**
-     * Generic constructor from existing command and responses properties.
-     * Should be used only in tests.
-     * @param commands Commands properties.
-     * @param responses Responses properties.
-     */
-    protected Language(
-        final Properties commands,
-        final Properties responses
-    ){
-        this.commands = commands;
-        this.responses = responses;
     }
 
     /**
@@ -128,8 +108,7 @@ public abstract class Language {
      * @return String reply or null if nothing is found.
      */
     public final String reply(final String key) {
-        final String reply = this.responses.getProperty(key);
-        return tryReplyFromLink(reply);
+        return followPossibleLink(this.responses.getProperty(key));
     }
 
     /**
@@ -137,79 +116,35 @@ public abstract class Language {
      * link (not starting with the right protocol), it will fallback
      * to the reply as string.
      * <br>
-     * Supported protocols:
-     * <ul>
-     *     <li>
-     *         <b>Classpath</b> loads the file from resources:
-     *         <br>
-     *         <code>
-     *             commands.comment=classpath:replies/commands.comment_en.md
-     *         </code>
-     *     </li>
-     *     <li>
-     *         <b>File</b> loads the file from file system by absolute path:
-     *         <br>
-     *         <code>
-     *             commands.comment=file:///<full_path>/commands.comment_en.md
-     *         </code>
-     *     </li>
-     *     <li>
-     *         <b>Http(s)</b> is doing a http(s) request:
-     *         <br>
-     *         <code>
-     *             commands.comment=http://my.docs.com/commands/comment
-     *         </code>
-     *     </li>
-     * </ul>
-     *
-     * If something goes wrong like IO exception, bad request etc...,
-     * it will return null.
+     * The link must start with <i>classpath:</i>.
+     * <br>
+     * Example:<br>
+     * <code>
+     *     commands.comment=classpath:replies/commands.comment_en.md
+     * </code>
      *
      * @param linkedReply Reply as link.
      * @return Actual reply fetched from link or null if something goes wrong.
-     * @checkstyle CyclomaticComplexity (60 lines).
-     * @checkstyle BooleanExpressionComplexity (20 lines).
      */
-    private String tryReplyFromLink(final String linkedReply){
+    private String followPossibleLink(final String linkedReply){
         final boolean isLinked = linkedReply != null
-            && (linkedReply.startsWith("http://")
-            || linkedReply.startsWith("https://")
-            || linkedReply.startsWith("file://")
-            || linkedReply.startsWith("classpath:")
-        );
+            && linkedReply.startsWith("classpath:")
+            && linkedReply.length() > "classpath:".length();
+
         String reply = null;
         if (isLinked) {
-            URL url = null;
-            if (linkedReply.startsWith("classpath:")) {
-                if (linkedReply.length() > "classpath:".length()) {
-                    final String path = linkedReply
-                        .split("classpath:")[1];
-                    url = this.getClass().getClassLoader().getResource(path);
-                }
-            } else {
-                try {
-                    url = new URL(linkedReply);
-                } catch (final MalformedURLException exception) {
-                    exception.printStackTrace();
-                    //no-op
-                }
-            }
+            final String path = linkedReply.split("classpath:")[1];
+            URL url =  this.getClass().getClassLoader().getResource(path);
             if (url != null) {
-                try {
-                    URLConnection connection = url.openConnection();
-                    try (
-                        final BufferedReader reader = new BufferedReader(
-                            new InputStreamReader(connection.getInputStream()))
-                    ) {
-                        reply = reader.lines().collect(Collectors
-                            .joining(System.lineSeparator()));
-                    } catch (final IOException exception) {
-                        exception.printStackTrace();
-                        //no-op
-                    }
+                try (
+                    final BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(url.openConnection()
+                            .getInputStream()))
+                ) {
+                    reply = reader.lines().collect(Collectors
+                        .joining(System.lineSeparator()));
                 } catch (final IOException exception) {
                     exception.printStackTrace();
-                    //no-op
                 }
             }
         }else{

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/Commands.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/Commands.java
@@ -56,7 +56,11 @@ public final class Commands implements Conversation {
         if(Event.Type.COMMANDS.equals(event.type())) {
             final Project project = event.project();
             final Language language = project.language();
-            final String reply = language.reply("commands.comment");
+            final String author = event.comment().author();
+            final String reply = String.format(
+                language.reply("commands.comment"),
+                author
+            );
             steps = new SendReply(reply);
         } else {
             steps = this.next.start(event);

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/Commands.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/Commands.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2020-2021, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core.managers;
+
+import com.selfxdsd.api.Event;
+import com.selfxdsd.api.Language;
+import com.selfxdsd.api.Project;
+import com.selfxdsd.api.pm.Conversation;
+import com.selfxdsd.api.pm.Step;
+
+/**
+ * Conversation where someone asks the PM about the available PM commands.
+ * @author criske
+ * @version $Id$
+ * @since 0.0.72
+ */
+public final class Commands implements Conversation {
+
+    /**
+     * Next conversation, if the event type is not "commands".
+     */
+    private final Conversation next;
+
+    /**
+     * Ctor.
+     * @param next Next in the conversation chain, if the
+     *  event type is not commands.
+     */
+    public Commands(final Conversation next) {
+        this.next = next;
+    }
+
+    @Override
+    public Step start(final Event event) {
+        final Step steps;
+        if(Event.Type.COMMANDS.equals(event.type())) {
+            final Project project = event.project();
+            final Language language = project.language();
+            final String reply = language.reply("commands.comment");
+            steps = new SendReply(reply);
+        } else {
+            steps = this.next.start(event);
+        }
+        return steps;
+    }
+}

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/StoredProjectManager.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/StoredProjectManager.java
@@ -47,6 +47,7 @@ import java.util.function.Supplier;
  * @version $Id$
  * @checkstyle ExecutableStatementCount (1000 lines)
  * @checkstyle ClassFanOutComplexity (1000 lines)
+ * @checkstyle ClassDataAbstractionCoupling (1000 lines)
  * @since 0.0.1
  */
 public final class StoredProjectManager implements ProjectManager {
@@ -556,12 +557,14 @@ public final class StoredProjectManager implements ProjectManager {
             );
             final Conversation conversation = new IgnoreBots(
                 new Understand(
-                    new Hello(
-                        new Status(
-                            new Resign(
-                                new Deregister(
-                                    new Register(
-                                        new Confused()
+                    new Commands(
+                        new Hello(
+                            new Status(
+                                new Resign(
+                                    new Deregister(
+                                        new Register(
+                                            new Confused()
+                                        )
                                     )
                                 )
                             )

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/CommandsTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/CommandsTestCase.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2020-2021, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core.managers;
+
+import com.selfxdsd.api.Event;
+import com.selfxdsd.api.Project;
+import com.selfxdsd.api.pm.Conversation;
+import com.selfxdsd.api.pm.Step;
+import com.selfxdsd.core.projects.English;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for {@link Commands}.
+ * @author criske
+ * @version $Id$
+ * @since 0.0.72
+ */
+public final class CommandsTestCase {
+
+    /**
+     * Commands.start(...) should return a SendReply step in case
+     * of a "commands" event.
+     */
+    @Test
+    public void returnsStepForCommands() {
+        final Event event = Mockito.mock(Event.class);
+        Mockito.when(event.type()).thenReturn(Event.Type.COMMANDS);
+
+        final Project project = Mockito.mock(Project.class);
+        Mockito.when(project.language()).thenReturn(new English());
+        Mockito.when(event.project()).thenReturn(project);
+
+        final Conversation commands = new Commands(
+            next -> {
+                throw new IllegalStateException(
+                    "Conversation should end with 'commands', "
+                    + "the next one in chain should not be called."
+                );
+            }
+        );
+
+        final Step step = commands.start(event);
+        MatcherAssert.assertThat(
+            step,
+            Matchers.allOf(
+                Matchers.notNullValue(),
+                Matchers.instanceOf(SendReply.class)
+            )
+        );
+    }
+
+    /**
+     * Commands.start(...) should call the next conversation if the
+     * given Event is not 'commands'.
+     */
+    @Test
+    public void goesFurtherIfNotCommands() {
+        final Step resolved = Mockito.mock(Step.class);
+        final Event event = Mockito.mock(Event.class);
+        Mockito.when(event.type()).thenReturn("notCommands");
+        final Conversation commands = new Commands(
+            next -> {
+                MatcherAssert.assertThat(event, Matchers.is(next));
+                return resolved;
+            }
+        );
+        MatcherAssert.assertThat(
+            commands.start(event),
+            Matchers.is(resolved)
+        );
+    }
+}

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/LanguageLinkedResponsesTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/LanguageLinkedResponsesTestCase.java
@@ -27,11 +27,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Properties;
-
 /**
  * Unit tests for {@link Language} linked responses.
  * @author criske
@@ -50,64 +45,24 @@ public final class LanguageLinkedResponsesTestCase {
         MatcherAssert.assertThat(
             english.reply("commands.comment"),
             Matchers.startsWith(
-                "* ``Hello`` -- any comment addressed"
+                "Hi @%s! Here are the commands which I understand:"
             )
         );
     }
 
     /**
-     * Language can follow a file linked from responses properties entry value.
-     * @throws IOException if something goes wrong.
-     * @checkstyle JavadocType (40 lines).
-     * @checkstyle JavadocMethod (40 lines).
+     * Language can follow a resource linked from responses properties entry
+     * value but returns null if the file resource is not found.
      */
     @Test
-    public void shouldReadReplyFromFileLink() throws IOException {
-        final Path file = Files.createTempFile("self-lang-comment-link",
-            "test");
-        Files.writeString(file, "* ``Hello`` -- any comment addressed");
-        final Properties commands = new Properties();
-        commands.putIfAbsent(
-            "commands.comment",
-            "file:///" + file.toAbsolutePath()
-        );
-        class TestLanguage extends Language {
-            TestLanguage() {
-                super(new Properties(), commands);
-            }
-        }
-        final Language language = new TestLanguage();
+    public void shouldFailToReadReplyFromClasspathLink() {
+        final Language english = new Language(
+            "commands_en.properties",
+            "responses_bad_link_en.properties") {
+        };
         MatcherAssert.assertThat(
-            language.reply("commands.comment"),
-            Matchers.startsWith(
-                "* ``Hello`` -- any comment addressed"
-            )
-        );
-        Files.delete(file);
-    }
-
-    /**
-     * Language can follow a http link from responses properties entry value.
-     * @checkstyle JavadocType (40 lines).
-     * @checkstyle JavadocMethod (40 lines).
-     */
-    @Test
-    public void shouldReadReplyFromHttpLink() {
-        final Properties commands = new Properties();
-        commands.putIfAbsent(
-            "commands.comment",
-            "https://raw.githubusercontent.com/self-xdsd/self-docs/"
-                + "master/projectmanager.md"
-        );
-        class TestLanguage extends Language {
-            TestLanguage() {
-                super(new Properties(), commands);
-            }
-        }
-        final Language language = new TestLanguage();
-        MatcherAssert.assertThat(
-            language.reply("commands.comment"),
-            Matchers.startsWith("---")
+            english.reply("commands.comment"),
+            Matchers.nullValue()
         );
     }
 }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/LanguageLinkedResponsesTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/LanguageLinkedResponsesTestCase.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2020-2021, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core.projects;
+
+import com.selfxdsd.api.Language;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+/**
+ * Unit tests for {@link Language} linked responses.
+ * @author criske
+ * @version $Id$
+ * @since 0.0.72
+ */
+public final class LanguageLinkedResponsesTestCase {
+
+    /**
+     * Language can follow a resource linked from responses properties entry
+     * value.
+     */
+    @Test
+    public void shouldReadReplyFromClasspathLink() {
+        final Language english = new English();
+        MatcherAssert.assertThat(
+            english.reply("commands.comment"),
+            Matchers.startsWith(
+                "* ``Hello`` -- any comment addressed"
+            )
+        );
+    }
+
+    /**
+     * Language can follow a file linked from responses properties entry value.
+     * @throws IOException if something goes wrong.
+     * @checkstyle JavadocType (40 lines).
+     * @checkstyle JavadocMethod (40 lines).
+     */
+    @Test
+    public void shouldReadReplyFromFileLink() throws IOException {
+        final Path file = Files.createTempFile("self-lang-comment-link",
+            "test");
+        Files.writeString(file, "* ``Hello`` -- any comment addressed");
+        final Properties commands = new Properties();
+        commands.putIfAbsent(
+            "commands.comment",
+            "file:///" + file.toAbsolutePath()
+        );
+        class TestLanguage extends Language {
+            TestLanguage() {
+                super(new Properties(), commands);
+            }
+        }
+        final Language language = new TestLanguage();
+        MatcherAssert.assertThat(
+            language.reply("commands.comment"),
+            Matchers.startsWith(
+                "* ``Hello`` -- any comment addressed"
+            )
+        );
+        Files.delete(file);
+    }
+
+    /**
+     * Language can follow a http link from responses properties entry value.
+     * @checkstyle JavadocType (40 lines).
+     * @checkstyle JavadocMethod (40 lines).
+     */
+    @Test
+    public void shouldReadReplyFromHttpLink() {
+        final Properties commands = new Properties();
+        commands.putIfAbsent(
+            "commands.comment",
+            "https://raw.githubusercontent.com/self-xdsd/self-docs/"
+                + "master/projectmanager.md"
+        );
+        class TestLanguage extends Language {
+            TestLanguage() {
+                super(new Properties(), commands);
+            }
+        }
+        final Language language = new TestLanguage();
+        MatcherAssert.assertThat(
+            language.reply("commands.comment"),
+            Matchers.startsWith("---")
+        );
+    }
+}

--- a/self-core-impl/src/test/resources/commands_en.properties
+++ b/self-core-impl/src/test/resources/commands_en.properties
@@ -12,3 +12,4 @@ deregister.command.two=remove
 register.command.one=register
 register.command.two=add
 status.command=status
+commands.command=commands

--- a/self-core-impl/src/test/resources/replies/commands.comment_en.md
+++ b/self-core-impl/src/test/resources/replies/commands.comment_en.md
@@ -1,0 +1,5 @@
+* ``Hello`` -- any comment addressed to the PM containing the word **"hello"**.
+* ``Status`` -- any comment addressed to the PM, containing the word **"status"**. The PM will respond with the Task's status, assignee, deadline etc.
+* ``Resign`` -- a task's assignee can always resign from the task, if they cannot or simply do not want to solve it. The comment should be addressed to the PM and contain the word **"resign"**. Only the task's assignee can give this command.
+* ``Deregister`` -- a task can be deregistered (taken out of scope) with a comment containing the word **"deregister"**. Only a Contributor with role ``PO`` or ``ARCH`` can give this command. When a task is deregistered, the task's assignee is automatically resigned.
+* ``Register`` -- an Issue or PR can be registered as a Task with a comment containing the word **"register"**. Any Contributor can give this command.

--- a/self-core-impl/src/test/resources/replies/commands.comment_en.md
+++ b/self-core-impl/src/test/resources/replies/commands.comment_en.md
@@ -1,5 +1,15 @@
+Hi @%s! Here are the commands which I understand:
+
 * ``Hello`` -- any comment addressed to the PM containing the word **"hello"**.
+    
+    Equivalent command: ``Hi``
 * ``Status`` -- any comment addressed to the PM, containing the word **"status"**. The PM will respond with the Task's status, assignee, deadline etc.
 * ``Resign`` -- a task's assignee can always resign from the task, if they cannot or simply do not want to solve it. The comment should be addressed to the PM and contain the word **"resign"**. Only the task's assignee can give this command.
+    
+    Equivalent commands: ``Refuse``, ``Quit``
 * ``Deregister`` -- a task can be deregistered (taken out of scope) with a comment containing the word **"deregister"**. Only a Contributor with role ``PO`` or ``ARCH`` can give this command. When a task is deregistered, the task's assignee is automatically resigned.
+
+    Equivalent command: ``Remove``
 * ``Register`` -- an Issue or PR can be registered as a Task with a comment containing the word **"register"**. Any Contributor can give this command.
+    
+    Equivalent command: ``Add``

--- a/self-core-impl/src/test/resources/responses_bad_link_en.properties
+++ b/self-core-impl/src/test/resources/responses_bad_link_en.properties
@@ -1,0 +1,1 @@
+commands.comment=classpath:replies/foo_en.md

--- a/self-core-impl/src/test/resources/responses_en.properties
+++ b/self-core-impl/src/test/resources/responses_en.properties
@@ -58,3 +58,4 @@ issueClosed.comment=@%s this Issue is closed. If you want me to do anything with
                     However, reopening issues is discouraged, please consider opening new tickets instead.
 manualAssignment.comment=@%s please keep in mind that manual assignment of tickets is a bad practice \
                          and it is discouraged. Next time, please let me elect the assignee.
+commands.comment=classpath:replies/commands.comment_en.md


### PR DESCRIPTION
This PR also introduces linked language responses. This means that a value for a response key could be a link
to a separate file that contains the actual reply. The file, depending on used link protocol, could be fetched locally (`file://`, `classpath:`) or remotely (`http(s)://`).

By doing this, larger and/or marked up replies can be easly maintainted in separate files rather than having them clobbered in the `responses.properites`.

PR for #1071 