### PR TITLE
#1084 account for contributor commission when paying

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/StoredPlatformInvoice.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/StoredPlatformInvoice.java
@@ -43,6 +43,8 @@ import java.util.Locale;
  * @since 0.0.50
  * @checkstyle TrailingComment (500 lines)
  * @checkstyle ExecutableStatementCount (500 lines)
+ * @todo #1084:60min Modify the pdf of the PlatformInvoice to print the sentence
+ *  "VAT reverse charge applies" if the VAT is negative.
  */
 public final class StoredPlatformInvoice implements PlatformInvoice {
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/StripeWalletITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/StripeWalletITCase.java
@@ -86,6 +86,9 @@ public final class StripeWalletITCase {
                 .thenReturn(BigDecimal.valueOf((108 + 1) * 100));
             Mockito.when(invoice.projectCommission()).thenReturn(BigDecimal
                 .valueOf(100));
+            Mockito.when(invoice.contributorCommission()).thenReturn(
+                BigDecimal.valueOf(20)
+            );
             Mockito.when(invoice.amount())
                 .thenReturn(BigDecimal.valueOf(108 * 100));
 


### PR DESCRIPTION
PR for #1084 

Contributor commission is deducted from the Contributor's gross earnings;
Contributor commission is taken into account when calculating the VAT;
Added the reverse charge (negate the VAT) for EU contributors which are paying VAT;
If reverse charge applies, VAT is NOT deducted from the Contributor's earnings;
Left puzzle to update the PlatformInvoice's PDF.