### PR TITLE
#1092 on_behalf_of for non-SEPA accounts

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/Country.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/Country.java
@@ -48,12 +48,31 @@ final class Country {
     );
 
     /**
+     * All the 27 EU countries + UK.
+     */
+    private static final List<String> SEPA_COUNTRIES = List.of(
+        "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE",
+        "FI", "FR", "DE", "GR", "HU", "IE", "IT", "LV",
+        "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK",
+        "SI", "ES", "SE", "GB"
+    );
+
+    /**
      * Is the given country from the EU?
      * @param country Country code.
      * @return True or false.
      */
     static boolean isFromEu(final String country) {
         return EU_COUNTRIES.contains(country.toUpperCase());
+    }
+
+    /**
+     * Is the given country from the SEPA region?
+     * @param country Country code.
+     * @return True or false.
+     */
+    static boolean isFromSepa(final String country) {
+        return SEPA_COUNTRIES.contains(country.toUpperCase());
     }
 
 }


### PR DESCRIPTION
Fixes #1092 

If the Connected Account is from a non-SEPA country, use ``on_behealf_of``.