### PR TITLE
#1097 PayoutMethod.canReceivePayments()

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/PayoutMethod.java
+++ b/self-api/src/main/java/com/selfxdsd/api/PayoutMethod.java
@@ -59,6 +59,14 @@ public interface PayoutMethod {
     BillingInfo billingInfo();
 
     /**
+     * Can this PayoutMethod be used to receive payments? Even if it is created,
+     * it might not be usable yet (the Contributor still needs to provide some
+     * data to Stripe).
+     * @return True of false.
+     */
+    boolean canReceivePayments();
+
+    /**
      * The whole PayoutMethod in JSON.
      * This usually comes from the API of the payment processor.
      * @return The PayoutMethod in JSON format.

--- a/self-core-impl/src/main/java/com/selfxdsd/core/contributors/StripePayoutMethod.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/contributors/StripePayoutMethod.java
@@ -64,6 +64,8 @@ public final class StripePayoutMethod implements PayoutMethod {
     /**
      * Stripe Connected Account. Make sure to read it from the API only once
      * and cache the result.
+     * @todo #1097:60min Initialize this Supplier in the Constructor, so we
+     *  can write proper unit tests for the methods which are using it.
      */
     private final Supplier<Account> connectedAccount = new Supplier<>() {
 
@@ -136,6 +138,26 @@ public final class StripePayoutMethod implements PayoutMethod {
     @Override
     public BillingInfo billingInfo() {
         return new AccountBillingInfo(this.connectedAccount.get());
+    }
+
+    @Override
+    public boolean canReceivePayments() {
+        final boolean canReceivePayments;
+        final Account account = this.connectedAccount.get();
+        final Account.Capabilities capabilities = account.getCapabilities();
+        if(capabilities != null) {
+            final String transfers = capabilities.getTransfers();
+            final String cardPayments = capabilities.getCardPayments();
+            if("active".equalsIgnoreCase(transfers)
+                && "active".equalsIgnoreCase(cardPayments)) {
+                canReceivePayments = true;
+            } else {
+                canReceivePayments = false;
+            }
+        } else {
+            canReceivePayments = false;
+        }
+        return canReceivePayments;
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StripeWallet.java
@@ -182,9 +182,21 @@ public final class StripeWallet implements Wallet {
                     + "PayoutMethod set up, cannot pay."
                 );
                 throw new WalletPaymentException(
-                    "Contributor " + contributor.username() + " hasn't "
-                    + "finished setting up their Stripe PayoutMethod."
+                    "Contributor " + contributor.username() + " has not "
+                    + "created their Stripe PayoutMethod yet."
                 );
+            } else {
+                if(!payoutMethod.canReceivePayments()) {
+                    LOG.error(
+                        "[STRIPE] Contributor " + contributor.username()
+                        + " from " + contributor.provider() + " hasn't finished "
+                        + "setting up their PayoutMethod, cannot pay."
+                    );
+                    throw new WalletPaymentException(
+                        "Contributor " + contributor.username() + " has not "
+                        + "finished setting up their Stripe PayoutMethod."
+                    );
+                }
             }
             final PaymentMethod paymentMethod = this.storage
                 .paymentMethods()

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/StripeWalletITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/StripeWalletITCase.java
@@ -143,6 +143,7 @@ public final class StripeWalletITCase {
             Mockito.when(
                 payoutsOfContrib.getByType(PayoutMethod.Type.STRIPE)
             ).thenReturn(payoutMethod);
+            Mockito.when(payoutMethod.canReceivePayments()).thenReturn(true);
             Mockito.when(payoutMethod.identifier()).thenReturn("ac_123");
 
             Mockito.when(storage.paymentMethods())


### PR DESCRIPTION
Fixes #1097 

Implemented PayoutMethod.canReceivePayments();
Used it inside StripeWallet.pay();
Left puzzle for unit testing of StripePayoutMethod;