### PR TITLE
#1109 Follow the Github project Owner

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Provider.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Provider.java
@@ -58,6 +58,13 @@ public interface Provider {
     Organizations organizations();
 
     /**
+     * The authenticated User will follow the given provider user.
+     * @param username Username of the user to follow.
+     * @return True if successful, false otherwise.
+     */
+    boolean follow(final String username);
+
+    /**
      * Return a Provider which has an access token.
      * @param accessToken Access token to make authorized requests with.
      * @return Provider.

--- a/self-core-impl/src/main/java/com/selfxdsd/core/Bitbucket.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/Bitbucket.java
@@ -139,6 +139,11 @@ public final class Bitbucket implements Provider {
     }
 
     @Override
+    public boolean follow(final String username) {
+        throw new UnsupportedOperationException("Not yet implemented.");
+    }
+
+    @Override
     public Provider withToken(final String accessToken) {
         return new Bitbucket(
             new BaseSelf.Authenticated(this.user, accessToken),

--- a/self-core-impl/src/main/java/com/selfxdsd/core/FollowProjectOwner.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/FollowProjectOwner.java
@@ -33,7 +33,7 @@ import javax.json.JsonObject;
  * Follow the PO after accepting the Invitation.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 0.0.75
+ * @since 0.0.76
  */
 final class FollowProjectOwner implements Invitation {
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/FollowProjectOwner.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/FollowProjectOwner.java
@@ -1,3 +1,25 @@
+/**
+ * Copyright (c) 2020-2021, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.selfxdsd.core;
 
 import com.selfxdsd.api.Invitation;
@@ -11,7 +33,7 @@ import javax.json.JsonObject;
  * Follow the PO after accepting the Invitation.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 0.0.37
+ * @since 0.0.75
  */
 final class FollowProjectOwner implements Invitation {
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/FollowProjectOwner.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/FollowProjectOwner.java
@@ -1,0 +1,64 @@
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Invitation;
+import com.selfxdsd.api.Repo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.json.JsonObject;
+
+/**
+ * Follow the PO after accepting the Invitation.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.37
+ */
+final class FollowProjectOwner implements Invitation {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(
+        FollowProjectOwner.class
+    );
+
+
+    /**
+     * Original Invitation.
+     */
+    private final Invitation origin;
+
+    /**
+     * Ctor.
+     * @param origin Original Invitation.
+     */
+    FollowProjectOwner(final Invitation origin) {
+        this.origin = origin;
+    }
+
+    @Override
+    public JsonObject json() {
+        return this.origin.json();
+    }
+
+    @Override
+    public String inviter() {
+        return this.origin.inviter();
+    }
+
+    @Override
+    public Repo repo() {
+        return this.origin.repo();
+    }
+
+    @Override
+    public void accept() {
+        this.origin.accept();
+        LOG.debug("Following PO...");
+        try {
+            this.repo().owner().provider().follow(this.inviter());
+        } catch (final IllegalStateException ex) {
+            LOG.error("Caught ISE while following PO", ex);
+        }
+    }
+}

--- a/self-core-impl/src/main/java/com/selfxdsd/core/Github.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/Github.java
@@ -25,6 +25,8 @@ package com.selfxdsd.core;
 import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
 
+import javax.json.Json;
+import java.net.HttpURLConnection;
 import java.net.URI;
 
 /**
@@ -138,7 +140,26 @@ public final class Github implements Provider {
 
     @Override
     public boolean follow(final String username) {
-        throw new UnsupportedOperationException("Not yet implemented.");
+        final boolean followed;
+        if(username == null || username.isEmpty()) {
+            followed = false;
+        } else {
+            final Resource response = this.resources.put(
+                URI.create(
+                    this.uri + "/user/following/" + username
+                ),
+                Json.createObjectBuilder().build()
+            );
+            final int status = response.statusCode();
+            if (status == HttpURLConnection.HTTP_NO_CONTENT) {
+                followed = true;
+            } else if (status == HttpURLConnection.HTTP_NOT_MODIFIED){
+                followed = true;
+            } else {
+                followed = false;
+            }
+        }
+        return followed;
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/Github.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/Github.java
@@ -137,6 +137,11 @@ public final class Github implements Provider {
     }
 
     @Override
+    public boolean follow(final String username) {
+        throw new UnsupportedOperationException("Not yet implemented.");
+    }
+
+    @Override
     public Provider withToken(final String accessToken) {
         return new Github(
             new BaseSelf.Authenticated(this.user, accessToken),

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepoInvitations.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepoInvitations.java
@@ -77,12 +77,14 @@ final class GithubRepoInvitations implements Invitations {
         final List<Invitation> invitations = this.fetchInvitations().stream()
             .map(
                 jsonValue -> new HelloIssue(
+                    new FollowProjectOwner(
                         new StarRepo(
                             new GithubInvitation(
                                 this.resources,
                                 this.repoInvitationsUri,
                                 (JsonObject) jsonValue,
                                 this.github
+                            )
                         )
                     )
                 )

--- a/self-core-impl/src/main/java/com/selfxdsd/core/Gitlab.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/Gitlab.java
@@ -33,6 +33,8 @@ import java.net.URI;
  * @version $Id$
  * @since 0.0.1
  * @todo #27:30min Continue adding integration tests for Gitlab provider.
+ * @todo #1109:60min Implement and test method follow(...) which should call
+ *  GitLab's API and follow the specified user.
  */
 public final class Gitlab implements Provider {
 
@@ -130,6 +132,11 @@ public final class Gitlab implements Provider {
             this.uri,
             this.user,
             this.storage);
+    }
+
+    @Override
+    public boolean follow(final String username) {
+        throw new UnsupportedOperationException("Not yet implemented.");
     }
 
     @Override

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepoInvitations.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepoInvitations.java
@@ -33,6 +33,9 @@ import java.util.Iterator;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.45
+ * @todo #1109:60min Always return a fake invitation wrapped inside the
+ *  StarRepo and FollowProjectOwner decorators, so we can star/follow GitLab
+ *  repos when "accepting" invitations.
  */
 final class GitlabRepoInvitations implements Invitations {
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/FollowProjectOwnerTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/FollowProjectOwnerTestCase.java
@@ -34,7 +34,7 @@ import javax.json.JsonObject;
 /**
  * Unit tests for {@link FollowProjectOwner}.
  * @author Mihai Andronache (amihaiemil@gmail.com)\
- * @since 0.0.75
+ * @since 0.0.76
  * @version $Id$
  */
 public final class FollowProjectOwnerTestCase {

--- a/self-core-impl/src/test/java/com/selfxdsd/core/FollowProjectOwnerTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/FollowProjectOwnerTestCase.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2020-2021, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.*;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+
+/**
+ * Unit tests for {@link FollowProjectOwner}.
+ * @author Mihai Andronache (amihaiemil@gmail.com)\
+ * @since 0.0.75
+ * @version $Id$
+ */
+public final class FollowProjectOwnerTestCase {
+
+    /**
+     * FollowProjectOwner delegates json() to the original Invitation.
+     */
+    @Test
+    public void delegatesJson() {
+        final JsonObject json = Json.createObjectBuilder().build();
+        final Invitation origin = Mockito.mock(Invitation.class);
+        Mockito.when(origin.json()).thenReturn(json);
+        final Invitation followPo = new FollowProjectOwner(origin);
+        MatcherAssert.assertThat(
+            followPo.json(),
+            Matchers.is(json)
+        );
+        Mockito.verify(origin, Mockito.times(1)).json();
+    }
+
+    /**
+     * FollowProjectOwner delegates inviter() to the original Invitation.
+     */
+    @Test
+    public void delegatesInviter() {
+        final Invitation origin = Mockito.mock(Invitation.class);
+        Mockito.when(origin.inviter()).thenReturn("mihai");
+        final Invitation followPo = new FollowProjectOwner(origin);
+        MatcherAssert.assertThat(
+            followPo.inviter(),
+            Matchers.is("mihai")
+        );
+        Mockito.verify(origin, Mockito.times(1)).inviter();
+    }
+
+    /**
+     * FollowProjectOwner delegates repo() to the original Invitation.
+     */
+    @Test
+    public void delegatesRepo() {
+        final Repo repo = Mockito.mock(Repo.class);
+        final Invitation origin = Mockito.mock(Invitation.class);
+        Mockito.when(origin.repo()).thenReturn(repo);
+        final Invitation followPo = new FollowProjectOwner(origin);
+        MatcherAssert.assertThat(
+            followPo.repo(),
+            Matchers.is(repo)
+        );
+        Mockito.verify(origin, Mockito.times(1)).repo();
+    }
+
+    /**
+     * FollowProjectOwner can accept the original invitation and follows the PO.
+     */
+    @Test
+    public void acceptsAndFollowsPo() {
+        final Provider provider = Mockito.mock(Provider.class);
+        final User owner = Mockito.mock(User.class);
+        Mockito.when(owner.provider()).thenReturn(provider);
+        final Repo repo = Mockito.mock(Repo.class);
+        Mockito.when(repo.owner()).thenReturn(owner);
+        final Invitation origin = Mockito.mock(Invitation.class);
+        Mockito.when(origin.repo()).thenReturn(repo);
+        Mockito.when(origin.inviter()).thenReturn("amihaiemil");
+
+        final Invitation followPo = new FollowProjectOwner(origin);
+
+        followPo.accept();
+
+        Mockito.verify(origin, Mockito.times(1)).accept();
+        Mockito.verify(origin, Mockito.times(1)).repo();
+        Mockito.verify(repo, Mockito.times(1)).owner();
+        Mockito.verify(owner, Mockito.times(1))
+            .provider();
+        Mockito.verify(provider, Mockito.times(1))
+            .follow("amihaiemil");
+    }
+}

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubTestCase.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2020-2021, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.core;
+
+import com.selfxdsd.api.Provider;
+import com.selfxdsd.api.User;
+import com.selfxdsd.api.storage.Storage;
+import com.selfxdsd.core.mock.MockJsonResources;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.json.JsonValue;
+import java.net.HttpURLConnection;
+
+/**
+ * Unit tests for {@link Github}.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @since 0.0.76
+ * @version $Id$
+ */
+public final class GithubTestCase {
+
+    /**
+     * Github can follow a user.
+     */
+    @Test
+    public void canFollowUser() {
+        final Provider github = new Github(
+            Mockito.mock(User.class),
+            Mockito.mock(Storage.class),
+            new MockJsonResources(
+                req -> {
+                    MatcherAssert.assertThat(
+                        req.getMethod(),
+                        Matchers.equalTo("PUT")
+                    );
+                    MatcherAssert.assertThat(
+                        req.getUri().toString(),
+                        Matchers.equalTo(
+                            "https://api.github.com/user/following/vlad"
+                        )
+                    );
+                    MatcherAssert.assertThat(
+                        req.getBody(),
+                        Matchers.equalTo(JsonValue.EMPTY_JSON_OBJECT)
+                    );
+                    return new MockJsonResources.MockResource(
+                        HttpURLConnection.HTTP_NO_CONTENT,
+                        JsonValue.EMPTY_JSON_OBJECT
+                    );
+                }
+            )
+        );
+        MatcherAssert.assertThat(
+            github.follow("vlad"),
+            Matchers.is(Boolean.TRUE)
+        );
+    }
+
+    /**
+     * Github follow returns an unexpected status, the returned value is false.
+     */
+    @Test
+    public void followReturnsUnexpectedStatus() {
+        final Provider github = new Github(
+            Mockito.mock(User.class),
+            Mockito.mock(Storage.class),
+            new MockJsonResources(
+                req -> {
+                    MatcherAssert.assertThat(
+                        req.getMethod(),
+                        Matchers.equalTo("PUT")
+                    );
+                    MatcherAssert.assertThat(
+                        req.getUri().toString(),
+                        Matchers.equalTo(
+                            "https://api.github.com/user/following/vlad"
+                        )
+                    );
+                    MatcherAssert.assertThat(
+                        req.getBody(),
+                        Matchers.equalTo(JsonValue.EMPTY_JSON_OBJECT)
+                    );
+                    return new MockJsonResources.MockResource(
+                        HttpURLConnection.HTTP_BAD_METHOD,
+                        JsonValue.EMPTY_JSON_OBJECT
+                    );
+                }
+            )
+        );
+        MatcherAssert.assertThat(
+            github.follow("vlad"),
+            Matchers.is(Boolean.FALSE)
+        );
+    }
+
+}


### PR DESCRIPTION
PR for #1109 

Implemented and tested Provider.follow(username);
Implemented and tested FollowProjectOwner;
Implemented following of the PO when accepting the invitation;
Left puzzles to continue with GitLab.