### PR TITLE
#1119. Fixed bug in Gitlab#findUserId.

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/Gitlab.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/Gitlab.java
@@ -25,6 +25,7 @@ package com.selfxdsd.core;
 import com.selfxdsd.api.*;
 import com.selfxdsd.api.storage.Storage;
 
+import javax.json.JsonArray;
 import javax.json.JsonValue;
 import java.net.HttpURLConnection;
 import java.net.URI;
@@ -183,7 +184,12 @@ public final class Gitlab implements Provider {
         );
         final int id;
         if (response.statusCode() == HttpURLConnection.HTTP_OK) {
-            id = response.asJsonObject().getInt("id");
+            final JsonArray result = response.asJsonArray();
+            if (!result.isEmpty()) {
+                id = result.get(0).asJsonObject().getInt("id");
+            } else {
+                id = -1;
+            }
         } else {
             id = -1;
         }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GitlabITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GitlabITCase.java
@@ -188,14 +188,19 @@ public final class GitlabITCase {
                     .endsWith("/users?username=john")) {
                     mock = new MockResource(
                         HttpURLConnection.HTTP_OK,
-                        Json.createObjectBuilder()
-                            .add("id", 1)
+                        Json.createArrayBuilder()
+                            .add(
+                                Json.createObjectBuilder()
+                                    .add("id", 1)
+                                    .build()
+                            )
                             .build()
+
                     );
                 } else {
                     mock = new MockResource(
-                        HttpURLConnection.HTTP_NOT_FOUND,
-                        JsonValue.NULL
+                        HttpURLConnection.HTTP_OK,
+                        JsonValue.EMPTY_JSON_ARRAY
                     );
                 }
             } else if ("POST".equals(method)) {


### PR DESCRIPTION
Fixed bug in Gitlab#findUserId(username) where result is an array of at most one element and not an object.
When user is not found, array is empty.

FIXES #1119