### PR TITLE
#1128 JsonResources allow specification of headers

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
@@ -42,9 +42,8 @@ import java.util.function.Supplier;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.8
- * @todo #252:30min Add other methods such as delete and
- *  continue abstracting the HTTP calls away from the Provider's
- *  implementations (Issues, Comments etc).
+ * @todo #1128:60min Continue adding overloaded methods to also accept headers
+ *  for PATCH, PUT and DELETE (see how GET and POST are overloaded).
  */
 public interface JsonResources {
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
@@ -92,6 +92,21 @@ public interface JsonResources {
     );
 
     /**
+     * Post a JsonObject to the specified URI.
+     * @param uri URI.
+     * @param headers HTTP Headers.
+     * @param body JSON body of the request.
+     * @return Resource.
+     * @throws IllegalStateException If IOException or InterruptedException
+     *  occur while making the HTTP request.
+     */
+    Resource post(
+        final URI uri,
+        final Supplier<Map<String, List<String>>> headers,
+        final JsonValue body
+    );
+
+    /**
      * Patch a JsonObject at the specified URI.
      * @param uri URI.
      * @param body JSON body of the request.
@@ -201,13 +216,22 @@ public interface JsonResources {
             final URI uri,
             final JsonValue body
         ) {
+            return this.post(uri, () -> new HashMap<>(), body);
+        }
+
+        @Override
+        public Resource post(
+            final URI uri,
+            final Supplier<Map<String, List<String>>> headers,
+            final JsonValue body
+        ) {
             try {
                 final HttpResponse<String> response = HttpClient.newHttpClient()
                     .send(
                         this.request(
                             uri,
                             "POST",
-                            new HashMap<>(),
+                            headers.get(),
                             HttpRequest.BodyPublishers.ofString(
                                 body.toString()
                             )
@@ -220,7 +244,7 @@ public interface JsonResources {
             } catch (final IOException | InterruptedException ex) {
                 throw new IllegalStateException(
                     "Couldn't POST " + body.toString()
-                  + " to [" + uri.toString() +"]",
+                    + " to [" + uri.toString() +"]",
                     ex
                 );
             }

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/MockJsonResources.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/MockJsonResources.java
@@ -140,10 +140,19 @@ public final class MockJsonResources implements JsonResources {
 
     @Override
     public Resource post(final URI uri, final JsonValue body) {
+        return this.post(uri, () -> new HashMap<>(), body);
+    }
+
+    @Override
+    public Resource post(
+        final URI uri,
+        final Supplier<Map<String, List<String>>> headers,
+        final JsonValue body
+    ) {
         final MockRequest request = new MockRequest(
             "POST",
             uri,
-            new HashMap<>(),
+            headers.get(),
             body,
             accessToken
         );

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/MockJsonResources.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/MockJsonResources.java
@@ -9,10 +9,9 @@ import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.json.JsonValue;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * A mock implementation of {@link JsonResources} used to unit test
@@ -121,9 +120,18 @@ public final class MockJsonResources implements JsonResources {
 
     @Override
     public Resource get(final URI uri) {
+        return this.get(uri, () -> new HashMap<>());
+    }
+
+    @Override
+    public Resource get(
+        final URI uri,
+        final Supplier<Map<String, List<String>>> headers
+    ) {
         final MockRequest request = new MockRequest(
             "GET",
             uri,
+            headers.get(),
             JsonValue.NULL,
             accessToken
         );
@@ -135,6 +143,7 @@ public final class MockJsonResources implements JsonResources {
         final MockRequest request = new MockRequest(
             "POST",
             uri,
+            new HashMap<>(),
             body,
             accessToken
         );
@@ -146,6 +155,7 @@ public final class MockJsonResources implements JsonResources {
         final MockRequest request = new MockRequest(
             "PATCH",
             uri,
+            new HashMap<>(),
             body,
             accessToken
         );
@@ -157,6 +167,7 @@ public final class MockJsonResources implements JsonResources {
         final MockRequest request = new MockRequest(
             "PUT",
             uri,
+            new HashMap<>(),
             body,
             this.accessToken
         );
@@ -168,6 +179,7 @@ public final class MockJsonResources implements JsonResources {
         final MockRequest request = new MockRequest(
             "DELETE",
             uri,
+            new HashMap<>(),
             body,
             this.accessToken
         );
@@ -195,6 +207,12 @@ public final class MockJsonResources implements JsonResources {
          * Request URI.
          */
         private final URI uri;
+
+        /**
+         * HTTP Headers.
+         */
+        private final Map<String, List<String>> headers;
+
         /**
          * Request body.
          */
@@ -208,15 +226,18 @@ public final class MockJsonResources implements JsonResources {
          * Ctor.
          * @param method Http method.
          * @param uri Request URI.
+         * @param headers HTTP Headers.
          * @param body Request body.
          * @param accessToken Access token for authenticated requests.
          */
         private MockRequest(final String method,
                             final URI uri,
+                            final Map<String, List<String>> headers,
                             final JsonValue body,
                             final AccessToken accessToken) {
             this.method = method;
             this.uri = uri;
+            this.headers = headers;
             this.body = body;
             this.accessToken = accessToken;
         }


### PR DESCRIPTION
Fixes #1128 

Overloaded GET and POST to also accept HTTP Headers;
Left puzzle for the rest of the methods.