### PR TITLE
Fixed slow integration tests.

### DIFF
--- a/self-core-impl/src/test/java/com/selfxdsd/core/JdkHttpITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/JdkHttpITCase.java
@@ -70,7 +70,7 @@ public final class JdkHttpITCase {
                 )
             ).start(this.resource.port())
         ) {
-            final JsonResources resources = new JsonResources.JdkHttp();
+            final JsonResources resources = new JsonResources.JdkHttp(true);
             final Resource response = resources.get(container.home());
             MatcherAssert.assertThat(
                 response.asJsonObject(),
@@ -101,7 +101,7 @@ public final class JdkHttpITCase {
                 new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED)
             ).start(this.resource.port())
         ) {
-            final JsonResources resources = new JsonResources.JdkHttp()
+            final JsonResources resources = new JsonResources.JdkHttp(true)
                 .authenticated(new AccessToken.Github("123token456"));
             final Resource response = resources.post(
                 container.home(), body
@@ -144,7 +144,7 @@ public final class JdkHttpITCase {
                 new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT)
             ).start(this.resource.port())
         ) {
-            final JsonResources resources = new JsonResources.JdkHttp()
+            final JsonResources resources = new JsonResources.JdkHttp(true)
                 .authenticated(new AccessToken.Github("123token456"));
             final Resource response = resources.patch(
                 container.home(), body
@@ -187,7 +187,7 @@ public final class JdkHttpITCase {
                 new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED)
             ).start(this.resource.port())
         ) {
-            final JsonResources resources = new JsonResources.JdkHttp()
+            final JsonResources resources = new JsonResources.JdkHttp(true)
                 .authenticated(new AccessToken.Github("123token456"));
             final Resource response = resources.put(
                 container.home(), body
@@ -230,7 +230,7 @@ public final class JdkHttpITCase {
                 new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED)
             ).start(this.resource.port())
         ) {
-            final JsonResources resources = new JsonResources.JdkHttp()
+            final JsonResources resources = new JsonResources.JdkHttp(true)
                 .authenticated(new AccessToken.Github("123token456"));
             final Resource response = resources.delete(
                 container.home(), body


### PR DESCRIPTION
Problem was that the version of Grizzly/MkGrizzlyContainer used in test doesn't support HTTP_2, the default protocol for jdk HTTPClient.
The fix was to add a flag to instruct the client to use HTTP_1_1.

This is why the client in each test hanged for about a minutes until gave up and throw EOFException.
Here is the debug log:
```java
DEBUG: [HttpClient-1-SelectorManager] [60s 747ms] SocketTube(1) got read EOF
DEBUG: [HttpClient-1-SelectorManager] [60s 747ms] SocketTube(1) pausing read event
DEBUG: [HttpClient-1-SelectorManager] [60s 748ms] SelectorAttachment Registering jdk.internal.net.http.SocketTube$InternalReadPublisher$ReadEvent@6897fcd7 for 0 (false)
DEBUG: [HttpClient-1-SelectorManager] [60s 748ms] SocketTube(1) completing subscriber
DEBUG: [HttpClient-1-SelectorManager] [60s 748ms] Http1AsyncReceiver(SocketTube(1)) onError: java.io.EOFException: EOF reached while reading
DEBUG: [HttpClient-1-SelectorManager] [60s 751ms] Http1AsyncReceiver(SocketTube(1)) recorded java.io.EOFException: EOF reached while reading
	 delegate: jdk.internal.net.http.Http1Response$BodyReader@5f338b22/parser=jdk.internal.net.http.ResponseContent$UnknownLengthBodyParser@2c0700d8		 queue.isEmpty: true java.io.EOFException: EOF reached while reading
java.io.EOFException: EOF reached while reading
	at java.net.http/jdk.internal.net.http.Http1AsyncReceiver$Http1TubeSubscriber.onComplete(Http1AsyncReceiver.java:596)
	at java.net.http/jdk.internal.net.http.SocketTube$InternalReadPublisher$ReadSubscription.signalCompletion(SocketTube.java:632)
	at java.net.http/jdk.internal.net.http.SocketTube$InternalReadPublisher$InternalReadSubscription.read(SocketTube.java:833)
	at java.net.http/jdk.internal.net.http.SocketTube$SocketFlowTask.run(SocketTube.java:175)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler$SchedulableTask.run(SequentialScheduler.java:198)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler.runOrSchedule(SequentialScheduler.java:271)
	at java.net.http/jdk.internal.net.http.common.SequentialScheduler.runOrSchedule(SequentialScheduler.java:224)
	at java.net.http/jdk.internal.net.http.SocketTube$InternalReadPublisher$InternalReadSubscription.signalReadable(SocketTube.java:763)
	at java.net.http/jdk.internal.net.http.SocketTube$InternalReadPublisher$ReadEvent.signalEvent(SocketTube.java:941)
	at java.net.http/jdk.internal.net.http.SocketTube$SocketFlowEvent.handle(SocketTube.java:245)
	at java.net.http/jdk.internal.net.http.HttpClientImpl$SelectorManager.handleEvent(HttpClientImpl.java:968)
	at java.net.http/jdk.internal.net.http.HttpClientImpl$SelectorManager.lambda$run$3(HttpClientImpl.java:923)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1507)
	at java.net.http/jdk.internal.net.http.HttpClientImpl$SelectorManager.run(HttpClientImpl.java:923)
DEBUG: [HttpClient-1-SelectorManager] [60s 752ms] SocketTube(1) leaving read() loop after EOF:  Reading: [ops=0, demand=0, stopped=true], Writing: [ops=0, demand=1]
DEBUG: [HttpClient-1-SelectorManager] [60s 752ms] SocketTube(1) Read scheduler stopped
```