### PR TITLE
Fixed bug where etag header with different casing is ignored.

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/ConditionalJsonResources.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/ConditionalJsonResources.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * Cacheable JSON Resources used by Provider.
@@ -193,15 +194,28 @@ public final class ConditionalJsonResources implements JsonResources {
      * @param resource Resource.
      */
     private void storeInCache(final URI uri, final Resource resource) {
-        final List<String> etag = resource.headers().get("ETag");
-        if (resource.statusCode() == HttpURLConnection.HTTP_OK
-            && (etag != null && !etag.isEmpty())) {
-            LOG.debug(
-                "Storing remote resource body for {} with ETag {}",
-                uri,
-                etag.get(0)
-            );
-            this.jsonStorage.store(uri, etag.get(0), resource.toString());
+        final List<String> etag = resource
+            .headers()
+            .entrySet()
+            .stream()
+            .filter(entry -> entry.getKey()
+                .equalsIgnoreCase("ETag"))
+            .flatMap(entry -> entry.getValue().stream())
+            .collect(Collectors.toList());
+        if (resource.statusCode() == HttpURLConnection.HTTP_OK) {
+            if (!etag.isEmpty()) {
+                LOG.debug(
+                    "Storing remote resource body for {} with ETag {}",
+                    uri,
+                    etag.get(0)
+                );
+                this.jsonStorage.store(uri, etag.get(0), resource.toString());
+            } else {
+                LOG.debug(
+                    "ETag header not found for {}. Caching is skipped.",
+                    uri
+                );
+            }
         }
     }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/ConditionalJsonResourcesTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/ConditionalJsonResourcesTestCase.java
@@ -75,7 +75,8 @@ public final class ConditionalJsonResourcesTestCase {
     }
 
     /**
-     * Should store in cache if Etag header is present.
+     * Should store in cache if Etag header is present. It also should
+     * ignore the header key casing when searching for etag header.
      */
     @Test
     public void shouldStoreInCacheWhenEntriesNotFound() {
@@ -85,7 +86,7 @@ public final class ConditionalJsonResourcesTestCase {
             .add("hello", "world")
             .build();
         final MockResource resource = new MockResource(200, body,
-            Map.of("ETag", List.of("etag-123"))
+            Map.of("eTaG", List.of("etag-123"))
         );
         final MockJsonResources resources = new MockJsonResources(
             req -> resource


### PR DESCRIPTION
This happens for gitlab header, where "ETag" is as "etag".
Because of this,  saving the Resource body into JsonStorage was skipped.

![gl_etag](https://user-images.githubusercontent.com/10284893/117316763-8fbdbe80-ae91-11eb-8e89-f224833e3b4f.png)

