### PR TITLE
#1171 split headers by comma manually

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Repos.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Repos.java
@@ -27,6 +27,8 @@ package com.selfxdsd.api;
  * @author criske
  * @version $Id$
  * @since 0.0.8
+ * @todo #1171:120min Implement and test GitlabPersonalRepos, which should
+ *  represent the user's public and private personal repositories.
  */
 public interface Repos extends Iterable<Repo> {
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubPersonalRepos.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubPersonalRepos.java
@@ -82,14 +82,6 @@ final class GithubPersonalRepos implements Repos {
         this.storage = storage;
     }
 
-    /**
-     * TODO #1166:60min Possible bug in class FromHeaders. The bellow method
-     *  works fine if we specify per_page=100. However, if we do not specify
-     *  per_page, the default value is 30 and FromHeaders behaves strangely:
-     *  at the first iteration, the next page is ?page=2 (correct), but at
-     *  the second iteration, the next page is ?page=1 (it should be page=3).
-     * @return Iterator of Repo.
-     */
     @Override
     public Iterator<Repo> iterator() {
         final List<Repo> repos = new ArrayList<>();

--- a/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
@@ -30,11 +30,10 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Supplier;
 
 /**
@@ -279,7 +278,7 @@ public interface JsonResources {
                 return new JsonResponse(
                     response.statusCode(),
                     response.body(),
-                    response.headers().map()
+                    this.headers(response.headers())
                 );
             } catch (final IOException | InterruptedException ex) {
                 throw new IllegalStateException(
@@ -311,7 +310,7 @@ public interface JsonResources {
                 return new JsonResponse(
                     response.statusCode(),
                     response.body(),
-                    response.headers().map()
+                    this.headers(response.headers())
                 );
             } catch (final IOException | InterruptedException ex) {
                 throw new IllegalStateException(
@@ -344,7 +343,7 @@ public interface JsonResources {
                 return new JsonResponse(
                     response.statusCode(),
                     response.body(),
-                    response.headers().map()
+                    this.headers(response.headers())
                 );
             } catch (final IOException | InterruptedException ex) {
                 throw new IllegalStateException(
@@ -377,7 +376,7 @@ public interface JsonResources {
                 return new JsonResponse(
                     response.statusCode(),
                     response.body(),
-                    response.headers().map()
+                    this.headers(response.headers())
                 );
             } catch (final IOException | InterruptedException ex) {
                 throw new IllegalStateException(
@@ -410,7 +409,7 @@ public interface JsonResources {
                 return new JsonResponse(
                     response.statusCode(),
                     response.body(),
-                    response.headers().map()
+                    this.headers(response.headers())
                 );
             } catch (final IOException | InterruptedException ex) {
                 throw new IllegalStateException(
@@ -476,6 +475,30 @@ public interface JsonResources {
                 client = HttpClient.newHttpClient();
             }
             return client;
+        }
+
+        /**
+         * Calling HttpHeaders.map() will return a Map<String, List<String>>,
+         * BUT it will not split the header's value by comma. We have to do
+         * that manually.
+         * @param headers Headers map with values list split by comma.
+         * @return Map.
+         * @checkstyle LineLength (10 lines)
+         * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpHeaders.html">HttpHeaders.map() JavaDoc.</a>
+         */
+        private Map<String, List<String>> headers(final HttpHeaders headers) {
+            final Map<String, List<String>> split = new HashMap<>();
+            final Map<String, List<String>> original = headers.map();
+            for(final Map.Entry<String, List<String>> header : original.entrySet()) {
+                final List<String> splitList = new ArrayList<>();
+                for(final String value : header.getValue()) {
+                    Arrays.asList(value.split(",")).stream().forEach(
+                        v -> splitList.add(v.trim())
+                    );
+                }
+                split.put(header.getKey(), splitList);
+            }
+            return split;
         }
     }
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/ResourcePaging.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/ResourcePaging.java
@@ -195,7 +195,10 @@ interface ResourcePaging extends Iterable<Resource> {
             private URI nextLink(
                 final Map<String, List<String>> headers
             ) {
-                List<String> links = headers.get("Link");
+                List<String> links = headers.getOrDefault(
+                    "Link",
+                    headers.get("link")
+                );
                 final URI next;
                 if (links == null) {
                     next = null;

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubTestCase.java
@@ -33,7 +33,6 @@ import org.mockito.Mockito;
 
 import javax.json.JsonValue;
 import java.net.HttpURLConnection;
-import java.util.Arrays;
 
 /**
  * Unit tests for {@link Github}.
@@ -48,8 +47,6 @@ public final class GithubTestCase {
      */
     @Test
     public void canFollowUser() {
-        final String orig = "oooooasdasdfdfdfdf";
-        System.out.println(Arrays.asList(orig.split(",")).toString());
         final Provider github = new Github(
             Mockito.mock(User.class),
             Mockito.mock(Storage.class),

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubTestCase.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 
 import javax.json.JsonValue;
 import java.net.HttpURLConnection;
+import java.util.Arrays;
 
 /**
  * Unit tests for {@link Github}.
@@ -47,6 +48,8 @@ public final class GithubTestCase {
      */
     @Test
     public void canFollowUser() {
+        final String orig = "oooooasdasdfdfdfdf";
+        System.out.println(Arrays.asList(orig.split(",")).toString());
         final Provider github = new Github(
             Mockito.mock(User.class),
             Mockito.mock(Storage.class),


### PR DESCRIPTION
PR for #1171 
Split JDK HttpHeaders by comma manually; 
