### PR TITLE
ConditionalResource for JsonStorage.

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/ConditionalResource.java
+++ b/self-api/src/main/java/com/selfxdsd/api/ConditionalResource.java
@@ -40,7 +40,7 @@ import java.util.Map;
 public interface ConditionalResource extends Resource {
 
     /**
-     * Uri of this resource. This should be also be a considered the
+     * Uri of this resource. This should be also considered the
      * storing key.
      *
      * @return URI.

--- a/self-api/src/main/java/com/selfxdsd/api/ConditionalResource.java
+++ b/self-api/src/main/java/com/selfxdsd/api/ConditionalResource.java
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) 2020-2021, Self XDSD Contributors
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to read the Software only. Permission is hereby NOT GRANTED to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.selfxdsd.api;
+
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Conditional {@link Resource}.
+ * A Resource is considered conditional if it has a eTag header in its
+ * response headers.
+ * @author criske
+ * @version $Id$
+ * @since 0.0.8
+ */
+public interface ConditionalResource extends Resource {
+
+    /**
+     * Uri of this resource. This should be also be a considered the
+     * storing key.
+     *
+     * @return URI.
+     */
+    URI uri();
+
+    /**
+     * ETag of this resource.
+     *
+     * @return String.
+     */
+    String etag();
+
+    /**
+     * Creation date of the conditional resource.
+     *
+     * @return LocalDateTime.
+     */
+    LocalDateTime creationDate();
+
+    /**
+     * Factory method that creates a ConditionalResource from a regular
+     * Resource.
+     * If the regular can't be conditional
+     * (no ETag header present in its response headers) it returns null.
+     *
+     * @param uri URI associated with the resource.
+     * @param resource Original Resource.
+     * @return ConditionalResource or null.
+     */
+    static ConditionalResource fromResource(
+        final URI uri,
+        final Resource resource
+    ) {
+        final ConditionalResource conditional;
+        if (resource instanceof ConditionalResource) {
+            conditional = (ConditionalResource) resource;
+        } else {
+            final String eTag = findEtag(resource);
+            if (eTag != null) {
+                conditional = new FromResource(resource, eTag, uri);
+            } else {
+                conditional = null;
+            }
+        }
+        return conditional;
+    }
+
+    /**
+     * Get ETag from resource headers.
+     *
+     * @param resource Resource.
+     * @return String or null if ETag was not found.
+     */
+    private static String findEtag(final Resource resource) {
+        return resource
+            .headers()
+            .entrySet()
+            .stream()
+            .filter(entry -> entry.getKey()
+                .equalsIgnoreCase("ETag"))
+            .flatMap(entry -> entry.getValue().stream())
+            .findFirst()
+            .orElse(null);
+    }
+
+
+    /**
+     * Conditional Resource created from a regular Resource.
+     * A Resource is considered conditional if it has eTag header in its
+     * response headers.
+     */
+    class FromResource implements ConditionalResource {
+
+        /**
+         * Original resource.
+         */
+        private final Resource original;
+
+        /**
+         * ETag.
+         */
+        private final String eTag;
+
+        /**
+         * URI.
+         */
+        private final URI uri;
+
+
+        /**
+         * Creation date.
+         */
+        private final LocalDateTime creationDate;
+
+        /**
+         * Ctr.
+         *
+         * @param original Resource.
+         * @param eTag Etag extracted from headers.
+         * @param uri URI.
+         */
+        private FromResource(
+            final Resource original,
+            final String eTag,
+            final URI uri
+        ) {
+            this.original = original;
+            this.eTag = eTag;
+            this.uri = uri;
+            this.creationDate = LocalDateTime.now();
+        }
+
+        @Override
+        public URI uri() {
+            return this.uri;
+        }
+
+        @Override
+        public String etag() {
+            return this.eTag;
+        }
+
+        @Override
+        public LocalDateTime creationDate() {
+            return this.creationDate;
+        }
+
+        @Override
+        public int statusCode() {
+            return this.original.statusCode();
+        }
+
+        @Override
+        public JsonObject asJsonObject() {
+            return this.original.asJsonObject();
+        }
+
+        @Override
+        public JsonArray asJsonArray() {
+            return this.original.asJsonArray();
+        }
+
+        @Override
+        public Map<String, List<String>> headers() {
+            return this.original.headers();
+        }
+
+        @Override
+        public Builder newBuilder() {
+            return new Builder(
+                this,
+                (code, body, headers) -> new FromResource(
+                    this.original.newBuilder()
+                        .status(code)
+                        .body(body.toString())
+                        .headers(h -> headers)
+                        .build(),
+                    eTag,
+                    uri
+                )
+            );
+        }
+
+        @Override
+        public String toString() {
+            return this.original.toString();
+        }
+    }
+}

--- a/self-api/src/main/java/com/selfxdsd/api/Resource.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Resource.java
@@ -20,7 +20,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.selfxdsd.core;
+package com.selfxdsd.api;
 
 import javax.json.Json;
 import javax.json.JsonArray;

--- a/self-api/src/main/java/com/selfxdsd/api/storage/JsonStorage.java
+++ b/self-api/src/main/java/com/selfxdsd/api/storage/JsonStorage.java
@@ -22,7 +22,7 @@
  */
 package com.selfxdsd.api.storage;
 
-import com.selfxdsd.api.ConditionalResource;
+import com.selfxdsd.api.CachedResource;
 
 import java.net.URI;
 import java.util.Map;
@@ -37,18 +37,18 @@ import java.util.concurrent.ConcurrentHashMap;
 public interface JsonStorage {
 
     /**
-     * Get conditional resource by its uri.
+     * Get cached resource by its uri.
      * @param uri URI.
      * @return Resource or null if not found.
      */
-    ConditionalResource getResource(final URI uri);
+    CachedResource getResource(final URI uri);
 
     /**
      * Store the resource.
      * @param resource Resource.
      * @return Stored Resource.
      */
-    ConditionalResource storeResource(ConditionalResource resource);
+    CachedResource storeResource(CachedResource resource);
 
     /**
      * In memory JsonStorage.
@@ -58,17 +58,17 @@ public interface JsonStorage {
         /**
          * Storage map.
          */
-        private final Map<URI, ConditionalResource> storage =
+        private final Map<URI, CachedResource> storage =
             new ConcurrentHashMap<>();
 
         @Override
-        public ConditionalResource getResource(final URI uri) {
+        public CachedResource getResource(final URI uri) {
             return storage.get(uri);
         }
 
         @Override
-        public ConditionalResource storeResource(
-            final ConditionalResource resource
+        public CachedResource storeResource(
+            final CachedResource resource
         ) {
             return storage.put(resource.uri(), resource);
         }

--- a/self-api/src/main/java/com/selfxdsd/api/storage/JsonStorage.java
+++ b/self-api/src/main/java/com/selfxdsd/api/storage/JsonStorage.java
@@ -22,6 +22,8 @@
  */
 package com.selfxdsd.api.storage;
 
+import com.selfxdsd.api.ConditionalResource;
+
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -35,26 +37,18 @@ import java.util.concurrent.ConcurrentHashMap;
 public interface JsonStorage {
 
     /**
-     * Return the ETag by URI.
+     * Get conditional resource by its uri.
      * @param uri URI.
-     * @return ETag or null if not found.
+     * @return Resource or null if not found.
      */
-    String getEtag(final URI uri);
+    ConditionalResource getResource(final URI uri);
 
     /**
-     * Get a cached resource body in JSON format by URI.
-     * @param uri URI.
-     * @return JsonValue or null if not found.
+     * Store the resource.
+     * @param resource Resource.
+     * @return Stored Resource.
      */
-    String getResourceBody(final URI uri);
-
-    /**
-     * Stores a resource from URI along with its etag in json format.
-     * @param uri URI.
-     * @param etag ETag.
-     * @param resource Resource in JSON.
-     */
-    void store(final URI uri, final String etag, final String resource);
+    ConditionalResource storeResource(ConditionalResource resource);
 
     /**
      * In memory JsonStorage.
@@ -64,61 +58,19 @@ public interface JsonStorage {
         /**
          * Storage map.
          */
-        private final Map<URI, Value> storage = new ConcurrentHashMap<>();
+        private final Map<URI, ConditionalResource> storage =
+            new ConcurrentHashMap<>();
 
         @Override
-        public String getEtag(final URI uri) {
-            final Value value = this.storage.get(uri);
-            String etag = null;
-            if (value != null) {
-                etag = value.etag;
-            }
-            return etag;
+        public ConditionalResource getResource(final URI uri) {
+            return storage.get(uri);
         }
 
         @Override
-        public String getResourceBody(final URI uri) {
-            final Value value = this.storage.get(uri);
-            String resource = null;
-            if (value != null) {
-                resource = value.resource;
-            }
-            return resource;
-        }
-
-        @Override
-        public void store(
-            final URI uri,
-            final String etag,
-            final String resource
+        public ConditionalResource storeResource(
+            final ConditionalResource resource
         ) {
-            this.storage.put(uri, new Value(etag, resource));
+            return storage.put(resource.uri(), resource);
         }
-
-        /**
-         * JsonStorage value wrapper.
-         */
-        private static final class Value {
-            /**
-             * Etag.
-             */
-            private final String etag;
-            /**
-             * Resource as JSON.
-             */
-            private final String resource;
-
-            /**
-             * Ctor.
-             * @param etag Etag.
-             * @param resource Resource as JSON.
-             */
-            private Value(final String etag, final String resource) {
-                this.etag = etag;
-                this.resource = resource;
-            }
-
-        }
-
     }
 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/BitbucketCommitComments.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/BitbucketCommitComments.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Comment;
 import com.selfxdsd.api.Comments;
+import com.selfxdsd.api.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/BitbucketCommits.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/BitbucketCommits.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Commit;
 import com.selfxdsd.api.Commits;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.storage.Storage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/BitbucketIssues.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/BitbucketIssues.java
@@ -25,6 +25,7 @@ package com.selfxdsd.core;
 import com.selfxdsd.api.Issue;
 import com.selfxdsd.api.Issues;
 import com.selfxdsd.api.Repo;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.storage.Storage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/BitbucketOrganizationRepos.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/BitbucketOrganizationRepos.java
@@ -2,6 +2,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Repo;
 import com.selfxdsd.api.Repos;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.User;
 import com.selfxdsd.api.storage.Storage;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/BitbucketOrganizations.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/BitbucketOrganizations.java
@@ -2,6 +2,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Organization;
 import com.selfxdsd.api.Organizations;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.User;
 import com.selfxdsd.api.storage.Storage;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/BitbucketWebhooks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/BitbucketWebhooks.java
@@ -23,6 +23,7 @@
 package com.selfxdsd.core;
 
 import com.selfxdsd.api.Project;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.Webhook;
 import com.selfxdsd.api.Webhooks;
 import com.selfxdsd.api.storage.Storage;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/ConditionalJsonResources.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/ConditionalJsonResources.java
@@ -168,7 +168,7 @@ public final class ConditionalJsonResources implements JsonResources {
                     LOG.debug(
                         "Storing remote resource body for {} with ETag {}",
                         uri,
-                        newConditional
+                        newConditional.etag()
                     );
                     resource = this.jsonStorage.storeResource(newConditional);
                 } else {
@@ -184,7 +184,7 @@ public final class ConditionalJsonResources implements JsonResources {
                     LOG.debug(
                         "Storing remote resource body for {} with ETag {}",
                         uri,
-                        newConditional
+                        newConditional.etag()
                     );
                     this.jsonStorage.storeResource(newConditional);
                 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/ConditionalJsonResources.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/ConditionalJsonResources.java
@@ -150,6 +150,11 @@ public final class ConditionalJsonResources implements JsonResources {
             final int status = remoteResource.statusCode();
 
             if (status == HttpURLConnection.HTTP_NOT_MODIFIED) {
+                LOG.debug(
+                    "Remote resource body for {} was not modified."
+                        + " Getting the resource body from json storage.",
+                    uri
+                );
                 resource = stored;
             } else {
                 LOG.debug(
@@ -160,6 +165,11 @@ public final class ConditionalJsonResources implements JsonResources {
                 final ConditionalResource newConditional = ConditionalResource
                     .fromResource(uri, remoteResource);
                 if (newConditional != null) {
+                    LOG.debug(
+                        "Storing remote resource body for {} with ETag {}",
+                        uri,
+                        newConditional
+                    );
                     resource = this.jsonStorage.storeResource(newConditional);
                 } else {
                     resource = remoteResource;
@@ -171,6 +181,11 @@ public final class ConditionalJsonResources implements JsonResources {
                 final ConditionalResource newConditional = ConditionalResource
                     .fromResource(uri, resource);
                 if (newConditional != null) {
+                    LOG.debug(
+                        "Storing remote resource body for {} with ETag {}",
+                        uri,
+                        newConditional
+                    );
                     this.jsonStorage.storeResource(newConditional);
                 }
             }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/ConditionalJsonResources.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/ConditionalJsonResources.java
@@ -22,6 +22,8 @@
  */
 package com.selfxdsd.core;
 
+import com.selfxdsd.api.ConditionalResource;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.storage.JsonStorage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +35,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * Cacheable JSON Resources used by Provider.
@@ -142,48 +143,36 @@ public final class ConditionalJsonResources implements JsonResources {
         final Supplier<Map<String, List<String>>> headers
     ) {
         final Resource resource;
-        final String etag = this.jsonStorage.getEtag(uri);
-        if (etag != null) {
+        final ConditionalResource stored = this.jsonStorage.getResource(uri);
+        if (stored != null) {
             final Resource remoteResource = this.delegate
-                .get(uri, this.ifNoneMatch(headers, etag));
+                .get(uri, this.ifNoneMatch(headers, stored.etag()));
             final int status = remoteResource.statusCode();
 
             if (status == HttpURLConnection.HTTP_NOT_MODIFIED) {
-                final String cachedBody = this.jsonStorage.getResourceBody(uri);
-                if (cachedBody != null) {
-                    LOG.debug(
-                        "Remote resource body for {} was not modified."
-                            + " Getting the resource body from json storage.",
-                        uri
-                    );
-                    resource = remoteResource
-                        .newBuilder()
-                        .status(HttpURLConnection.HTTP_OK)
-                        .body(cachedBody)
-                        .build();
-                } else {
-                    LOG.debug(
-                        "Remote resource for {} was not modified"
-                            + " but resource body is missing from json storage."
-                            + " Getting the resource from remote.",
-                        uri
-                    );
-                    resource = this.delegate.get(uri, headers);
-                    this.storeInCache(uri, resource);
-                }
+                resource = stored;
             } else {
                 LOG.debug(
                     "Remote resource body for {} was modified or "
                         + " has an unexpected status code.",
                     uri
                 );
-                resource = remoteResource;
-                this.storeInCache(uri, resource);
+                final ConditionalResource newConditional = ConditionalResource
+                    .fromResource(uri, remoteResource);
+                if (newConditional != null) {
+                    resource = this.jsonStorage.storeResource(newConditional);
+                } else {
+                    resource = remoteResource;
+                }
             }
         } else {
             resource = this.delegate.get(uri, headers);
             if (!this.cacheControlNoCache(headers)) {
-                this.storeInCache(uri, resource);
+                final ConditionalResource newConditional = ConditionalResource
+                    .fromResource(uri, resource);
+                if (newConditional != null) {
+                    this.jsonStorage.storeResource(newConditional);
+                }
             }
         }
         return resource;
@@ -200,38 +189,6 @@ public final class ConditionalJsonResources implements JsonResources {
         List<String> entry = headers.get().get("Cache-Control");
         return entry != null && !entry.isEmpty()
             && entry.get(0).equalsIgnoreCase("no-cache");
-    }
-
-    /**
-     * Store the Resource in json storage only if Etag header is present
-     * and resource's status is HttpURLConnection.OK.
-     * @param uri URI.
-     * @param resource Resource.
-     */
-    private void storeInCache(final URI uri, final Resource resource) {
-        final List<String> etag = resource
-            .headers()
-            .entrySet()
-            .stream()
-            .filter(entry -> entry.getKey()
-                .equalsIgnoreCase("ETag"))
-            .flatMap(entry -> entry.getValue().stream())
-            .collect(Collectors.toList());
-        if (resource.statusCode() == HttpURLConnection.HTTP_OK) {
-            if (!etag.isEmpty()) {
-                LOG.debug(
-                    "Storing remote resource body for {} with ETag {}",
-                    uri,
-                    etag.get(0)
-                );
-                this.jsonStorage.store(uri, etag.get(0), resource.toString());
-            } else {
-                LOG.debug(
-                    "ETag header not found for {}. Caching is skipped.",
-                    uri
-                );
-            }
-        }
     }
 
     /**

--- a/self-core-impl/src/main/java/com/selfxdsd/core/ConditionalJsonResources.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/ConditionalJsonResources.java
@@ -22,7 +22,7 @@
  */
 package com.selfxdsd.core;
 
-import com.selfxdsd.api.ConditionalResource;
+import com.selfxdsd.api.CachedResource;
 import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.storage.JsonStorage;
 import org.slf4j.Logger;
@@ -143,7 +143,7 @@ public final class ConditionalJsonResources implements JsonResources {
         final Supplier<Map<String, List<String>>> headers
     ) {
         final Resource resource;
-        final ConditionalResource stored = this.jsonStorage.getResource(uri);
+        final CachedResource stored = this.jsonStorage.getResource(uri);
         if (stored != null) {
             final Resource remoteResource = this.delegate
                 .get(uri, this.ifNoneMatch(headers, stored.etag()));
@@ -162,15 +162,15 @@ public final class ConditionalJsonResources implements JsonResources {
                         + " has an unexpected status code.",
                     uri
                 );
-                final ConditionalResource newConditional = ConditionalResource
+                final CachedResource cached = CachedResource
                     .fromResource(uri, remoteResource);
-                if (newConditional != null) {
+                if (cached != null) {
                     LOG.debug(
                         "Storing remote resource body for {} with ETag {}",
                         uri,
-                        newConditional.etag()
+                        cached.etag()
                     );
-                    resource = this.jsonStorage.storeResource(newConditional);
+                    resource = this.jsonStorage.storeResource(cached);
                 } else {
                     resource = remoteResource;
                 }
@@ -178,15 +178,15 @@ public final class ConditionalJsonResources implements JsonResources {
         } else {
             resource = this.delegate.get(uri, headers);
             if (!this.cacheControlNoCache(headers)) {
-                final ConditionalResource newConditional = ConditionalResource
+                final CachedResource cached = CachedResource
                     .fromResource(uri, resource);
-                if (newConditional != null) {
+                if (cached != null) {
                     LOG.debug(
                         "Storing remote resource body for {} with ETag {}",
                         uri,
-                        newConditional.etag()
+                        cached.etag()
                     );
-                    this.jsonStorage.storeResource(newConditional);
+                    this.jsonStorage.storeResource(cached);
                 }
             }
         }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubCollaborators.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubCollaborators.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Collaborator;
 import com.selfxdsd.api.Collaborators;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.storage.Storage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubCommitComments.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubCommitComments.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Comment;
 import com.selfxdsd.api.Comments;
+import com.selfxdsd.api.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubCommits.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubCommits.java
@@ -26,6 +26,8 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.util.Iterator;
 import javax.json.JsonObject;
+
+import com.selfxdsd.api.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.selfxdsd.api.Commit;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubInvitation.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubInvitation.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Invitation;
 import com.selfxdsd.api.Repo;
+import com.selfxdsd.api.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssueComments.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssueComments.java
@@ -2,6 +2,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Comment;
 import com.selfxdsd.api.Comments;
+import com.selfxdsd.api.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssueLabels.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssueLabels.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Label;
 import com.selfxdsd.api.Labels;
+import com.selfxdsd.api.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssues.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubIssues.java
@@ -25,6 +25,7 @@ package com.selfxdsd.core;
 import com.selfxdsd.api.Issue;
 import com.selfxdsd.api.Issues;
 import com.selfxdsd.api.Repo;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.storage.Storage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubOrganizationRepos.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubOrganizationRepos.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Repo;
 import com.selfxdsd.api.Repos;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.User;
 import com.selfxdsd.api.storage.Storage;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubOrganizations.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubOrganizations.java
@@ -2,6 +2,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Organization;
 import com.selfxdsd.api.Organizations;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.User;
 import com.selfxdsd.api.storage.Storage;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubPersonalRepos.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubPersonalRepos.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Repo;
 import com.selfxdsd.api.Repos;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.User;
 import com.selfxdsd.api.storage.Storage;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepoInvitations.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepoInvitations.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Invitation;
 import com.selfxdsd.api.Invitations;
+import com.selfxdsd.api.Resource;
 
 import javax.json.JsonArray;
 import javax.json.JsonObject;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepoLabels.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepoLabels.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Label;
 import com.selfxdsd.api.Labels;
+import com.selfxdsd.api.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubStars.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubStars.java
@@ -1,5 +1,6 @@
 package com.selfxdsd.core;
 
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.Stars;
 import com.selfxdsd.api.storage.Storage;
 import org.slf4j.Logger;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubWebhooks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubWebhooks.java
@@ -23,6 +23,7 @@
 package com.selfxdsd.core;
 
 import com.selfxdsd.api.Project;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.Webhook;
 import com.selfxdsd.api.Webhooks;
 import com.selfxdsd.api.storage.Storage;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborators.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCollaborators.java
@@ -2,6 +2,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Collaborator;
 import com.selfxdsd.api.Collaborators;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.storage.Storage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCommitComments.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCommitComments.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Comment;
 import com.selfxdsd.api.Comments;
+import com.selfxdsd.api.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCommits.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabCommits.java
@@ -25,6 +25,7 @@ package com.selfxdsd.core;
 import com.selfxdsd.api.Collaborators;
 import com.selfxdsd.api.Commit;
 import com.selfxdsd.api.Commits;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.storage.Storage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabIssueComments.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabIssueComments.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.json.Json;
 import javax.json.JsonObject;
+
+import com.selfxdsd.api.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabIssueLabels.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabIssueLabels.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Label;
 import com.selfxdsd.api.Labels;
+import com.selfxdsd.api.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabIssues.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabIssues.java
@@ -25,6 +25,7 @@ package com.selfxdsd.core;
 import com.selfxdsd.api.Issue;
 import com.selfxdsd.api.Issues;
 import com.selfxdsd.api.Repo;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.storage.Storage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabOrganizationRepos.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabOrganizationRepos.java
@@ -2,6 +2,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Repo;
 import com.selfxdsd.api.Repos;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.User;
 import com.selfxdsd.api.storage.Storage;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabOrganizations.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabOrganizations.java
@@ -2,6 +2,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Organization;
 import com.selfxdsd.api.Organizations;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.User;
 import com.selfxdsd.api.storage.Storage;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepoLabels.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepoLabels.java
@@ -24,6 +24,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Label;
 import com.selfxdsd.api.Labels;
+import com.selfxdsd.api.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabStars.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabStars.java
@@ -23,6 +23,7 @@
 package com.selfxdsd.core;
 
 import com.selfxdsd.api.Repo;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.Stars;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabWebhooks.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabWebhooks.java
@@ -23,6 +23,7 @@
 package com.selfxdsd.core;
 
 import com.selfxdsd.api.Project;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.Webhook;
 import com.selfxdsd.api.Webhooks;
 import com.selfxdsd.api.storage.Storage;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/JsonResources.java
@@ -22,6 +22,8 @@
  */
 package com.selfxdsd.core;
 
+import com.selfxdsd.api.Resource;
+
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;

--- a/self-core-impl/src/main/java/com/selfxdsd/core/ResourcePaging.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/ResourcePaging.java
@@ -22,6 +22,7 @@
  */
 package com.selfxdsd.core;
 
+import com.selfxdsd.api.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/self-core-impl/src/main/java/com/selfxdsd/core/RestfulSelfTodos.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/RestfulSelfTodos.java
@@ -23,6 +23,7 @@
 package com.selfxdsd.core;
 
 import com.selfxdsd.api.Project;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.SelfTodos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/self-core-impl/src/test/java/com/selfxdsd/core/ConditionalJsonResourcesTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/ConditionalJsonResourcesTestCase.java
@@ -22,18 +22,22 @@
  */
 package com.selfxdsd.core;
 
+import com.selfxdsd.api.ConditionalResource;
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.storage.JsonStorage;
 import com.selfxdsd.core.mock.MockJsonResources;
 import com.selfxdsd.core.mock.MockJsonResources.MockResource;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import javax.json.Json;
 import javax.json.JsonValue;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -67,9 +71,7 @@ public final class ConditionalJsonResourcesTestCase {
 
         Mockito
             .verify(storage, Mockito.never())
-            .store(
-                Mockito.any(),
-                Mockito.any(),
+            .storeResource(
                 Mockito.any()
             );
     }
@@ -100,9 +102,7 @@ public final class ConditionalJsonResourcesTestCase {
 
         Mockito
             .verify(storage, Mockito.never())
-            .store(
-                Mockito.any(),
-                Mockito.any(),
+            .storeResource(
                 Mockito.any()
             );
     }
@@ -129,10 +129,11 @@ public final class ConditionalJsonResourcesTestCase {
         );
 
         final Resource result = cacheResources.get(uri);
+        final ConditionalResource stored = storage.getResource(uri);
         MatcherAssert.assertThat(result, Matchers.equalTo(resource));
-        MatcherAssert.assertThat(storage.getEtag(uri),
+        MatcherAssert.assertThat(stored.etag(),
             Matchers.equalTo("etag-123"));
-        MatcherAssert.assertThat(storage.getResourceBody(uri),
+        MatcherAssert.assertThat(stored.toString(),
             Matchers.equalTo(body.toString()));
     }
 
@@ -161,9 +162,17 @@ public final class ConditionalJsonResourcesTestCase {
         final JsonResources cacheResources = new ConditionalJsonResources(
             resources, storage
         );
-
-        Mockito.when(storage.getEtag(uri)).thenReturn("etag-123");
-        Mockito.when(storage.getResourceBody(uri)).thenReturn(body.toString());
+        Mockito.when(storage.getResource(uri)).thenReturn(
+            ConditionalResource
+                .fromResource(
+                    uri,
+                    new MockResource(
+                        HttpURLConnection.HTTP_OK,
+                        body,
+                        Map.of("ETag", List.of("etag-123"))
+                    )
+                )
+        );
 
         final Resource result = cacheResources.get(
             uri,
@@ -216,9 +225,19 @@ public final class ConditionalJsonResourcesTestCase {
         final JsonResources cacheResources = new ConditionalJsonResources(
             resources, storage
         );
-
-        Mockito.when(storage.getEtag(uri)).thenReturn("etag-123");
-        Mockito.when(storage.getResourceBody(uri)).thenReturn(body.toString());
+        Mockito.when(storage.getResource(uri)).thenReturn(
+            ConditionalResource
+                .fromResource(
+                    uri,
+                    new MockResource(
+                        HttpURLConnection.HTTP_OK,
+                        body,
+                        Map.of("ETag", List.of("etag-123"))
+                    )
+                )
+        );
+        Mockito.when(storage.storeResource(Mockito.any()))
+            .thenAnswer(invocation -> invocation.getArguments()[0]);
 
         final Resource result = cacheResources.get(uri);
         final MockRequest req = resources.requests().first();
@@ -232,62 +251,24 @@ public final class ConditionalJsonResourcesTestCase {
         MatcherAssert.assertThat(result.toString(), Matchers.equalTo(
             newBody.toString()
         ));
-        
-        Mockito.verify(storage).store(uri, "etag-124", newBody.toString());
-    }
 
-    /**
-     * Should get Resource from remote if etag is present but 
-     * resource is missing.
-     */
-    @Test
-    public void shouldGetFromRemoteIfResourceEntryIsMissing(){
-        final URI uri = URI.create("/");
-        final JsonValue body = Json.createObjectBuilder()
-            .add("hello", "world")
-            .build();
-        
-        final JsonStorage storage = Mockito.mock(JsonStorage.class);
-        final MockJsonResources resources = new MockJsonResources(
-            req -> {
-                final boolean hasCheckHeader = req.getHeaders()
-                    .containsKey("If-None-Match");
-                final MockResource res;
-                if (hasCheckHeader) {
-                    res = new MockResource(
-                        HttpURLConnection.HTTP_NOT_MODIFIED,
-                        JsonValue.NULL,
-                        Map.of("ETag", List.of("etag-123"))
-                    );
-                } else {
-                    res = new MockResource(
-                        HttpURLConnection.HTTP_OK,
-                        body,
-                        Map.of("ETag", List.of("etag-123"))
-                    );
-                }
-                return res;
-            }
-        );
-        final JsonResources cacheResources = new ConditionalJsonResources(
-            resources, storage
-        );
-
-        Mockito.when(storage.getEtag(uri)).thenReturn("etag-123");
-
-        final Resource result = cacheResources.get(uri);
+        final ArgumentCaptor<ConditionalResource> captor = ArgumentCaptor
+            .forClass(ConditionalResource.class);
+        Mockito.verify(storage).storeResource(captor.capture());
+        final ConditionalResource storing = captor.getValue();
         MatcherAssert.assertThat(
-            resources.requests().first().getHeaders().get("If-None-Match"),
-            Matchers.equalTo(List.of("etag-123"))
+            storing.uri(), Matchers.equalTo(uri)
         );
-        MatcherAssert.assertThat(result.statusCode(), Matchers.is(
-            HttpURLConnection.HTTP_OK
-        ));
-        MatcherAssert.assertThat(result.toString(), Matchers.equalTo(
-            body.toString()
-        ));
-
-        Mockito.verify(storage).store(uri, "etag-123", body.toString());
+        MatcherAssert.assertThat(
+            storing.toString(), Matchers.equalTo(newBody.toString())
+        );
+        MatcherAssert.assertThat(
+            storing.etag(), Matchers.equalTo("etag-124")
+        );
+        MatcherAssert.assertThat(
+            storing.creationDate().toLocalDate(),
+            Matchers.equalTo(LocalDate.now())
+        );
     }
 
     /**

--- a/self-core-impl/src/test/java/com/selfxdsd/core/ConditionalJsonResourcesTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/ConditionalJsonResourcesTestCase.java
@@ -22,7 +22,7 @@
  */
 package com.selfxdsd.core;
 
-import com.selfxdsd.api.ConditionalResource;
+import com.selfxdsd.api.CachedResource;
 import com.selfxdsd.api.Resource;
 import com.selfxdsd.api.storage.JsonStorage;
 import com.selfxdsd.core.mock.MockJsonResources;
@@ -129,7 +129,7 @@ public final class ConditionalJsonResourcesTestCase {
         );
 
         final Resource result = cacheResources.get(uri);
-        final ConditionalResource stored = storage.getResource(uri);
+        final CachedResource stored = storage.getResource(uri);
         MatcherAssert.assertThat(result, Matchers.equalTo(resource));
         MatcherAssert.assertThat(stored.etag(),
             Matchers.equalTo("etag-123"));
@@ -163,7 +163,7 @@ public final class ConditionalJsonResourcesTestCase {
             resources, storage
         );
         Mockito.when(storage.getResource(uri)).thenReturn(
-            ConditionalResource
+            CachedResource
                 .fromResource(
                     uri,
                     new MockResource(
@@ -226,7 +226,7 @@ public final class ConditionalJsonResourcesTestCase {
             resources, storage
         );
         Mockito.when(storage.getResource(uri)).thenReturn(
-            ConditionalResource
+            CachedResource
                 .fromResource(
                     uri,
                     new MockResource(
@@ -252,10 +252,10 @@ public final class ConditionalJsonResourcesTestCase {
             newBody.toString()
         ));
 
-        final ArgumentCaptor<ConditionalResource> captor = ArgumentCaptor
-            .forClass(ConditionalResource.class);
+        final ArgumentCaptor<CachedResource> captor = ArgumentCaptor
+            .forClass(CachedResource.class);
         Mockito.verify(storage).storeResource(captor.capture());
-        final ConditionalResource storing = captor.getValue();
+        final CachedResource storing = captor.getValue();
         MatcherAssert.assertThat(
             storing.uri(), Matchers.equalTo(uri)
         );
@@ -298,7 +298,7 @@ public final class ConditionalJsonResourcesTestCase {
             resources, storage
         );
         Mockito.when(storage.getResource(uri)).thenReturn(
-            ConditionalResource
+            CachedResource
                 .fromResource(
                     uri,
                     new MockResource(

--- a/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssueCommentsITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/GithubIssueCommentsITCase.java
@@ -2,6 +2,7 @@ package com.selfxdsd.core;
 
 import com.selfxdsd.api.Comment;
 import com.selfxdsd.api.Comments;
+import com.selfxdsd.api.Resource;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;

--- a/self-core-impl/src/test/java/com/selfxdsd/core/JdkHttpITCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/JdkHttpITCase.java
@@ -26,6 +26,7 @@ import com.jcabi.http.mock.MkAnswer;
 import com.jcabi.http.mock.MkContainer;
 import com.jcabi.http.mock.MkGrizzlyContainer;
 import com.jcabi.http.mock.MkQuery;
+import com.selfxdsd.api.Resource;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Rule;

--- a/self-core-impl/src/test/java/com/selfxdsd/core/ResourcePagingTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/ResourcePagingTestCase.java
@@ -1,5 +1,6 @@
 package com.selfxdsd.core;
 
+import com.selfxdsd.api.Resource;
 import com.selfxdsd.core.mock.MockJsonResources;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;

--- a/self-core-impl/src/test/java/com/selfxdsd/core/mock/MockJsonResources.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/mock/MockJsonResources.java
@@ -2,7 +2,7 @@ package com.selfxdsd.core.mock;
 
 import com.selfxdsd.core.AccessToken;
 import com.selfxdsd.core.JsonResources;
-import com.selfxdsd.core.Resource;
+import com.selfxdsd.api.Resource;
 
 import javax.json.Json;
 import javax.json.JsonArray;


### PR DESCRIPTION
PR for #1177 

This PR address the problem of multiple db trips when ConditionalJsonResources
checks for etag and body in JsonStorage. By providing a higher abstraction ConditionalResource, an extension of Resource
and therefore changing the original  JsonStorage API, all checks are done at once.

The only downside is that Resource API has to be moved to self-api module in order to be extended by ConditionalResource.