### PR TITLE
#1199 Event changes for REPO_RENAMED

### DIFF
--- a/self-api/src/main/java/com/selfxdsd/api/Event.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Event.java
@@ -103,6 +103,11 @@ public interface Event {
         public static final String ISSUE_COMMENT = "issue_comment";
 
         /**
+         * Event for renaming a repo.
+         */
+        public static final String REPO_RENAMED = "repo_renamed";
+
+        /**
          * Hello comment event.
          */
         public static final String HELLO = "hello";

--- a/self-api/src/main/java/com/selfxdsd/api/Event.java
+++ b/self-api/src/main/java/com/selfxdsd/api/Event.java
@@ -57,6 +57,12 @@ public interface Event {
     Commit commit();
 
     /**
+     * New name (simple name, without owner) of the Repo.
+     * @return String if this event is REPO_ENAMED, null otherwise.
+     */
+    String repoNewName();
+
+    /**
      * Project where this event occured.
      * @return Project.
      */

--- a/self-core-impl/src/main/java/com/selfxdsd/core/BitbucketRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/BitbucketRepo.java
@@ -104,6 +104,11 @@ final class BitbucketRepo extends BaseRepo {
                 }
 
                 @Override
+                public String repoNewName() {
+                    return null;
+                }
+
+                @Override
                 public Project project() {
                     return project;
                 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepo.java
@@ -105,6 +105,11 @@ final class GithubRepo extends BaseRepo {
                 }
 
                 @Override
+                public String repoNewName() {
+                    return null;
+                }
+
+                @Override
                 public Project project() {
                     return project;
                 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GitlabRepo.java
@@ -127,6 +127,11 @@ final class GitlabRepo extends BaseRepo {
                 }
 
                 @Override
+                public String repoNewName() {
+                    return null;
+                }
+
+                @Override
                 public Project project() {
                     return project;
                 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/managers/Understand.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/managers/Understand.java
@@ -76,6 +76,11 @@ public final class Understand implements Conversation {
                 }
 
                 @Override
+                public String repoNewName() {
+                    return event.repoNewName();
+                }
+
+                @Override
                 public Project project() {
                     return event.project();
                 }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/GithubWebhookEvent.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/GithubWebhookEvent.java
@@ -83,6 +83,13 @@ final class GithubWebhookEvent implements Event {
             } else {
                 resolved = type;
             }
+        } else if("repository".equalsIgnoreCase(type)){
+            final String act = event.getString("action");
+            if("renamed".equalsIgnoreCase(act)) {
+                resolved = Type.REPO_RENAMED;
+            } else {
+                resolved = type;
+            }
         } else {
             resolved = type;
         }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/GithubWebhookEvent.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/GithubWebhookEvent.java
@@ -137,6 +137,18 @@ final class GithubWebhookEvent implements Event {
     }
 
     @Override
+    public String repoNewName() {
+        final String repoNewName;
+        if(Type.REPO_RENAMED.equalsIgnoreCase(this.type())) {
+            repoNewName = this.event.getJsonObject("repository")
+                .getString("name");
+        } else {
+            repoNewName = null;
+        }
+        return repoNewName;
+    }
+
+    @Override
     public Project project() {
         return project;
     }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/GitlabWebhookEvent.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/GitlabWebhookEvent.java
@@ -221,6 +221,13 @@ final class GitlabWebhookEvent implements Event {
     }
 
     @Override
+    public String repoNewName() {
+        throw new UnsupportedOperationException(
+            "GitLab doesn't support Webhook for REPO_RENAMED!"
+        );
+    }
+
+    @Override
     public Project project() {
         return this.project;
     }

--- a/self-core-impl/src/main/java/com/selfxdsd/core/projects/StoredProject.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/projects/StoredProject.java
@@ -49,7 +49,7 @@ import java.util.Objects;
  *  It should decide what kind of event has occurred and delegate it
  *  further to the ProjectManager who will deal with it. We still need
  *  the Issue Assigned case and Comment Created case.
- * @todo #1996:30min Add the Project_Renamed case to the resolve(...) method
+ * @todo #1199:60min Add the REPO_RENAMED case to the resolve(...) method
  *  and forward the call to the ProjectManager to take care of it.
  */
 public final class StoredProject implements Project {

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/StoredProjectManagerTestCase.java
@@ -460,6 +460,11 @@ public final class StoredProjectManagerTestCase {
                 }
 
                 @Override
+                public String repoNewName() {
+                    return null;
+                }
+
+                @Override
                 public Project project() {
                     return project;
                 }
@@ -527,6 +532,11 @@ public final class StoredProjectManagerTestCase {
 
                 @Override
                 public Commit commit() {
+                    return null;
+                }
+
+                @Override
+                public String repoNewName() {
                     return null;
                 }
 
@@ -606,6 +616,11 @@ public final class StoredProjectManagerTestCase {
 
                 @Override
                 public Commit commit() {
+                    return null;
+                }
+
+                @Override
+                public String repoNewName() {
                     return null;
                 }
 
@@ -691,6 +706,11 @@ public final class StoredProjectManagerTestCase {
                 }
 
                 @Override
+                public String repoNewName() {
+                    return null;
+                }
+
+                @Override
                 public Project project() {
                     return project;
                 }
@@ -762,6 +782,11 @@ public final class StoredProjectManagerTestCase {
 
                 @Override
                 public Commit commit() {
+                    return null;
+                }
+
+                @Override
+                public String repoNewName() {
                     return null;
                 }
 
@@ -840,6 +865,11 @@ public final class StoredProjectManagerTestCase {
 
                 @Override
                 public Commit commit() {
+                    return null;
+                }
+
+                @Override
+                public String repoNewName() {
                     return null;
                 }
 
@@ -924,6 +954,11 @@ public final class StoredProjectManagerTestCase {
                 }
 
                 @Override
+                public String repoNewName() {
+                    return null;
+                }
+
+                @Override
                 public Project project() {
                     return project;
                 }
@@ -1001,6 +1036,11 @@ public final class StoredProjectManagerTestCase {
 
                 @Override
                 public Commit commit() {
+                    return null;
+                }
+
+                @Override
+                public String repoNewName() {
                     return null;
                 }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/managers/UnderstandTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/managers/UnderstandTestCase.java
@@ -90,6 +90,11 @@ public final class UnderstandTestCase {
                 }
 
                 @Override
+                public String repoNewName() {
+                    return null;
+                }
+
+                @Override
                 public Project project() {
                     return project;
                 }
@@ -145,6 +150,11 @@ public final class UnderstandTestCase {
 
                 @Override
                 public Commit commit() {
+                    return null;
+                }
+
+                @Override
+                public String repoNewName() {
                     return null;
                 }
 

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/GithubWebhookEventTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/GithubWebhookEventTestCase.java
@@ -115,6 +115,49 @@ public final class GithubWebhookEventTestCase {
         );
     }
 
+    /**
+     * GithubWebhookEvent can return the repoNewName if the type is
+     * REPO_RENAMED.
+     */
+    @Test
+    public void returnsRepoNewNameIfTypeRenamed() {
+        final Project project = Mockito.mock(Project.class);
+        final Event event = new GithubWebhookEvent(
+            project,
+            "repository",
+            Json.createObjectBuilder()
+                .add("action", "renamed")
+                .add(
+                    "repository",
+                    Json.createObjectBuilder()
+                        .add("name", "new_name")
+                        .build()
+                ).build().toString()
+        );
+        MatcherAssert.assertThat(
+            event.repoNewName(),
+            Matchers.equalTo("new_name")
+        );
+    }
+
+    /**
+     * GithubWebhookEvent returns null repoNewName if type is not REPO_RENAMED.
+     */
+    @Test
+    public void returnsNullRepoNewNameIfTypeNotRenamed() {
+        final Project project = Mockito.mock(Project.class);
+        final Event event = new GithubWebhookEvent(
+            project,
+            "repository",
+            Json.createObjectBuilder()
+                .add("action", "publicised")
+                .build().toString()
+        );
+        MatcherAssert.assertThat(
+            event.repoNewName(),
+            Matchers.nullValue()
+        );
+    }
 
     /**
      * GithubWebhookEvent can return the newIssue PR type.

--- a/self-core-impl/src/test/java/com/selfxdsd/core/projects/GithubWebhookEventTestCase.java
+++ b/self-core-impl/src/test/java/com/selfxdsd/core/projects/GithubWebhookEventTestCase.java
@@ -100,6 +100,21 @@ public final class GithubWebhookEventTestCase {
         );
     }
 
+    /**
+     * GithubWebhookEvent can return the REPO_RENAMED type.
+     */
+    @Test
+    public void returnsRepoRenameType() {
+        final Project project = Mockito.mock(Project.class);
+        final Event event = new GithubWebhookEvent(
+            project, "repository", "{\"action\":\"renamed\"}"
+        );
+        MatcherAssert.assertThat(
+            event.type(),
+            Matchers.equalTo(Event.Type.REPO_RENAMED)
+        );
+    }
+
 
     /**
      * GithubWebhookEvent can return the newIssue PR type.


### PR DESCRIPTION
PR for #1199

Modified GithubWebhookEvent.type() to return REPO_RENAMED and added tests; 
Implemented and tested GithubWebhookEvent.repoNewName();
Apparently Gitlab doesn't send Webhook request for repo renaming so this is unsupported;
Left puzzle to continue with resolving the event further.