### PR TITLE
#1252 unit tests for GithubRepo.enableIssues()

### DIFF
--- a/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepo.java
+++ b/self-core-impl/src/main/java/com/selfxdsd/core/GithubRepo.java
@@ -36,8 +36,6 @@ import java.net.URI;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
- * @todo #1248:60min Write some integration tests using MkGrizzly server for
- *  method enableIssues().
  */
 final class GithubRepo extends BaseRepo {
 


### PR DESCRIPTION
PR for #1252 
Used ``MockJsonResources`` instead of MkGrizzly, as other tests.